### PR TITLE
Implemented fixes for Add-VMImage

### DIFF
--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -79,8 +79,8 @@ Function Add-VMImage{
 
         [Parameter(ParameterSetName='VMImageFromLocal')]
         [Parameter(ParameterSetName='VMImageFromAzure')]
-        [string] $CreateGalleryItem = $true
-        )
+        [bool] $CreateGalleryItem = $true
+    )
 
     if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('title'))
     {
@@ -95,9 +95,9 @@ Function Add-VMImage{
     }
 
     
-	$resourceGroupName = "addvmimageresourcegroup"
-	$storageAccountName = "addvmimagestorageaccount"
-	$containerName = "addvmimagecontainer"
+    $resourceGroupName = "addvmimageresourcegroup"
+    $storageAccountName = "addvmimagestorageaccount"
+    $containerName = "addvmimagecontainer"
     $subscriptionName = "Default Provider Subscription"
 
     $endpoints = (Invoke-RestMethod -Uri https://api.$azureStackDomain/metadata/endpoints?api-version=1.0 -Method Get)
@@ -124,8 +124,8 @@ Function Add-VMImage{
     New-AzureRmResourceGroup -Name $resourceGroupName -Location $location 
     $storageAccount = New-AzureRmStorageAccount -Name $storageAccountName -Location $location -ResourceGroupName $resourceGroupName -Type Standard_LRS
     Set-AzureRmCurrentStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName
-	New-AzureStorageContainer -Name $containerName  -Permission Blob
-	
+    New-AzureStorageContainer -Name $containerName  -Permission Blob
+
     if($pscmdlet.ParameterSetName -eq "VMImageFromLocal")
     {
         $script:osDiskName = Split-Path $osDiskLocalPath -Leaf
@@ -147,12 +147,12 @@ Function Add-VMImage{
 
     $powershellClientId = "0a7bdc5c-7b57-40be-9939-d4c5fc7cd417"
 
-	$adminToken = Get-AzureStackToken `
-		-Authority $authority `
-		-Resource $activeDirectoryServiceEndpointResourceId `
-		-AadTenantId $tenantID `
-		-ClientId $powershellClientId `
-		-Credential $azureStackCredentials
+    $adminToken = Get-AzureStackToken `
+        -Authority $authority `
+        -Resource $activeDirectoryServiceEndpointResourceId `
+        -AadTenantId $tenantID `
+        -ClientId $powershellClientId `
+        -Credential $azureStackCredentials
 
     $headers =  @{ Authorization = ("Bearer $adminToken") }
 
@@ -209,10 +209,10 @@ Function Add-VMImage{
     {
         if ($dataDiskBlobURIs.Count -ne 0)
         {
-             $dataDisksJSON = '"DataDisks":['
-             $i = 0
-             foreach($dataDiskBlobURI in $dataDiskBlobURIs)
-             {
+            $dataDisksJSON = '"DataDisks":['
+            $i = 0
+            foreach($dataDiskBlobURI in $dataDiskBlobURIs)
+            {
                 if($i -ne 0)
                 {
                     $dataDisksJSON = $dataDisksJSON +', '
@@ -222,25 +222,25 @@ Function Add-VMImage{
                 $dataDisksJSON = $dataDisksJSON + $newDataDisk;
             
                 ++$i
-             }
+            }
 
-             $dataDisksJSON = $dataDisksJSON +']'
-       }
-   }
+            $dataDisksJSON = $dataDisksJSON +']'
+        }
+    }
 
-   #building ARMResource
+    #building ARMResource
 
-   $propertyBody = $osDiskJSON 
+    $propertyBody = $osDiskJSON 
 
-   if(![string]::IsNullOrEmpty($dataDisksJson))
-   {
-       $propertyBody = $propertyBody + ', ' + $dataDisksJson
-   }
+    if(![string]::IsNullOrEmpty($dataDisksJson))
+    {
+        $propertyBody = $propertyBody + ', ' + $dataDisksJson
+    }
 
-   if(![string]::IsNullOrEmpty($detailsJson))
-   {
-       $propertyBody = $propertyBody + ', ' + $detailsJson
-   }
+    if(![string]::IsNullOrEmpty($detailsJson))
+    {
+        $propertyBody = $propertyBody + ', ' + $detailsJson
+    }
 
     $RequestBody = '{"Properties":{'+$propertyBody+'}}'
 
@@ -258,7 +258,7 @@ Function Add-VMImage{
 
         if($platformImage.Properties.ProvisioningState -eq 'Canceled')
         {
-            Write-Host "PVM image download was canceled.";
+            Write-Host "VM image download was canceled.";
             break;
         }
 
@@ -300,7 +300,7 @@ Function Add-VMImage{
         }
 
         $name = (New-Guid).guid
-	
+
         $JSON.name = $name
         $JSON.publisher = $publisher
         $JSON.version = $version
@@ -328,13 +328,13 @@ Function Add-VMImage{
 
         $JSON.longSummary = $descriptionToSet
         $JSON.description = $descriptionToSet
-		$JSON.summary = $descriptionToSet
+        $JSON.summary = $descriptionToSet
         $JSON | ConvertTo-Json -Compress | set-content $stringsPath
-		
-		Invoke-WebRequest -Uri http://www.aka.ms/azurestackmarketplaceitem -OutFile $compressedGalleryPackagerPath
-		
-		[System.IO.Compression.ZipFile]::ExtractToDirectory($compressedGalleryPackagerPath, $extractedGalleryPackagerPath)
-		
+
+        Invoke-WebRequest -Uri http://www.aka.ms/azurestackmarketplaceitem -OutFile $compressedGalleryPackagerPath
+
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($compressedGalleryPackagerPath, $extractedGalleryPackagerPath)
+
         $extractedGalleryPackagerExePath = Join-Path $extractedGalleryPackagerPath "Azure Stack Marketplace Item Generator and Sample\AzureGalleryPackageGenerator"
 
         $galleryItemName = $publisher + "." + $name + "." + $version + ".azpkg"
@@ -353,13 +353,13 @@ Function Add-VMImage{
         $blob = Set-AzureStorageBlobContent –Container $containerName –File $newPKGPath –Blob $galleryItemName
 
         Add-AzureRMGalleryItem -SubscriptionId $subscription.Subscription.SubscriptionId -GalleryItemUri $galleryItemURI -ApiVersion 2015-04-01
-		
+
         #cleanup
         Remove-Item $extractedGalleryItemPath -recurse -Force
-		Remove-Item $extractedGalleryPackagerPath -recurse -Force
-		Remove-Item $compressedGalleryPackagerPath
+        Remove-Item $extractedGalleryPackagerPath -recurse -Force
+        Remove-Item $compressedGalleryPackagerPath
     }
-	
+
     Remove-AzureStorageContainer –Name $containerName -Force
     Remove-AzureRmStorageAccount -ResourceGroupName $resourceGroupName -AccountName $storageAccountName 
     Remove-AzureRmResourceGroup -Name $resourceGroupName -Force

--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -84,14 +84,12 @@ Function Add-VMImage{
 
     if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('title'))
     {
-        throw "The title parameter only applies to creating a gallery item."
-        exit
+        Write-Error -Message "The title parameter only applies to creating a gallery item." -ErrorAction Stop
     }
 
     if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('description'))
     {
-        throw "The description parameter only applies to creating a gallery item."
-        exit
+        Write-Error -Message "The description parameter only applies to creating a gallery item." -ErrorAction Stop
     }
 
     
@@ -119,18 +117,33 @@ Function Add-VMImage{
     $profile = Add-AzureRmAccount -Environment $environment -Credential $azureStackCredentials
 
     Select-AzureRmProfile -Profile $profile
-    $subscription = Get-AzureRmSubscription -SubscriptionName $subscriptionName  | Select-AzureRmSubscription
+    $subscription = Get-AzureRmSubscription -SubscriptionName $subscriptionName | Select-AzureRmSubscription
 
-    New-AzureRmResourceGroup -Name $resourceGroupName -Location $location 
-    $storageAccount = New-AzureRmStorageAccount -Name $storageAccountName -Location $location -ResourceGroupName $resourceGroupName -Type Standard_LRS
+    #pre validate if image is not already deployed
+    if (Get-AzureRmVMImage -Location $location -PublisherName $publisher -Offer $offer -Skus $sku -Version $version -ErrorAction SilentlyContinue) {
+        Write-Error -Message ('VM Image with publisher "{0}", offer "{1}", sku "{2}", version "{3}" already is present. Please remove it first or change on of the values' -f $publisher,$offer,$sku,$version) -ErrorAction Stop
+    }
+
+    #potentially the RG was not cleaned up when exception happened in previous run. Test for exist
+    if (-not (Get-AzureRmResourceGroup -Name $resourceGroupName -Location $location -ErrorAction SilentlyContinue)) {
+        New-AzureRmResourceGroup -Name $resourceGroupName -Location $location 
+    }
+
+    #same for storage
+    if (-not (Get-AzureRmStorageAccount -Name $storageAccountName -ResourceGroupName $resourceGroupName -ErrorAction SilentlyContinue)) {
+        $storageAccount = New-AzureRmStorageAccount -Name $storageAccountName -Location $location -ResourceGroupName $resourceGroupName -Type Standard_LRS
+    }
     Set-AzureRmCurrentStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName
-    New-AzureStorageContainer -Name $containerName  -Permission Blob
+    #same for container
+    if (-not (Get-AzureStorageContainer -Name $containerName -ErrorAction SilentlyContinue)) {
+        New-AzureStorageContainer -Name $containerName -Permission Blob
+    }
 
     if($pscmdlet.ParameterSetName -eq "VMImageFromLocal")
     {
         $script:osDiskName = Split-Path $osDiskLocalPath -Leaf
         $script:osDiskBlobURIFromLocal = "https://$storageAccountName.blob.$azureStackDomain/$containerName/$osDiskName"
-        Add-AzureRmVhd  -Destination $osDiskBlobURIFromLocal -ResourceGroupName $resourceGroupName -LocalFilePath $osDiskLocalPath
+        Add-AzureRmVhd -Destination $osDiskBlobURIFromLocal -ResourceGroupName $resourceGroupName -LocalFilePath $osDiskLocalPath -OverWrite
 
         $script:dataDiskBlobURIsFromLocal = New-Object System.Collections.ArrayList
         if ($PSBoundParameters.ContainsKey('dataDisksLocalPaths'))
@@ -140,7 +153,7 @@ Function Add-VMImage{
                 $dataDiskName = Split-Path $dataDiskLocalPath -Leaf
                 $dataDiskBlobURI = "https://$storageAccountName.blob.$azureStackDomain/$containerName/$dataDiskName"
                 $dataDiskBlobURIsFromLocal.Add($dataDiskBlobURI) 
-                Add-AzureRmVhd  -Destination $dataDiskBlobURI -ResourceGroupName $resourceGroupName -LocalFilePath $dataDiskLocalPath 
+                Add-AzureRmVhd  -Destination $dataDiskBlobURI -ResourceGroupName $resourceGroupName -LocalFilePath $dataDiskLocalPath -OverWrite
             }
         }
     }
@@ -161,7 +174,7 @@ Function Add-VMImage{
     $uri = $uri + '/offers/' + $offer + '/skus/' + $sku + '/versions/' + $version + '?api-version=2015-12-01-preview'
 
 
-#building platform image JSON
+    #building platform image JSON
 
     #building osDisk json
     if($pscmdlet.ParameterSetName -eq "VMImageFromLocal")
@@ -252,25 +265,23 @@ Function Add-VMImage{
     {
         if($platformImage.Properties.ProvisioningState -eq 'Failed')
         {
-            Write-Host "VM image download failed.";
-            break;
+            Write-Error -Message "VM image download failed." -ErrorAction Stop
         }
 
         if($platformImage.Properties.ProvisioningState -eq 'Canceled')
         {
-            Write-Host "VM image download was canceled.";
-            break;
+            Write-Error -Message "VM image download was canceled." -ErrorAction Stop
         }
 
         Write-Host "Downloading";
-        Start-Sleep -s 4
+        Start-Sleep -Seconds 4
         $platformImage = Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
     }
 
     if($CreateGalleryItem -eq $true -And $platformImage.Properties.ProvisioningState -eq 'Succeeded')
     {
         Add-Type -AssemblyName System.IO.Compression.FileSystem
-        $basePath = Split-Path -Parent  $MyInvocation.MyCommand.Module.Path
+        $basePath = Split-Path -Parent $MyInvocation.MyCommand.Module.Path
         $compressedGalleryItemPath = Join-Path $basePath 'CustomizedVMGalleryItem.azpkg'
         $extractedGalleryItemPath = Join-Path $basePath 'galleryItem'
 
@@ -355,8 +366,8 @@ Function Add-VMImage{
         Add-AzureRMGalleryItem -SubscriptionId $subscription.Subscription.SubscriptionId -GalleryItemUri $galleryItemURI -ApiVersion 2015-04-01
 
         #cleanup
-        Remove-Item $extractedGalleryItemPath -recurse -Force
-        Remove-Item $extractedGalleryPackagerPath -recurse -Force
+        Remove-Item $extractedGalleryItemPath -Recurse -Force
+        Remove-Item $extractedGalleryPackagerPath -Recurse -Force
         Remove-Item $compressedGalleryPackagerPath
     }
 

--- a/ComputeAdmin/Tests/ComputeAdmin.Tests.ps1
+++ b/ComputeAdmin/Tests/ComputeAdmin.Tests.ps1
@@ -1,0 +1,45 @@
+$ModuleName = 'AzureStack.ComputeAdmin'
+$ModuleImportFile = 'AzureStack.ComputeAdmin.psm1'
+
+$ModuleRoot = (Resolve-Path $PSScriptRoot\..).Path
+Import-Module $script:ModuleRoot\$script:ModuleImportFile -Force
+
+Describe $script:ModuleName {
+    Context 'Module should be imported correctly' {
+        It "$script:ModuleName module is imported" {
+            Get-Module -Name $script:ModuleName |
+                Should Not Be $null
+        }
+
+        It 'Add-VMImage should be exported' {
+            Get-Command -Name Add-VMImage -ErrorAction SilentlyContinue | 
+                Should Not Be $null
+        }
+    }
+}
+
+InModuleScope $script:ModuleName {
+
+    $AddVMImageArgs = @{
+        publisher = 'Testing'
+        offer = 'Test'
+        sku = '2016'
+        version = '1.0.0'
+        osType = 'Windows'
+        osDiskLocalPath = '.\Test.vhd'
+        tenantID = 'TestTenantId.onmicrosoft.com'
+        azureStackCredentials = [pscredential]::new('testuser',(ConvertTo-SecureString -String 'testpass' -AsPlainText -Force))
+    }
+
+    Describe 'Parameter combinations' {
+        It 'CreateGalleryItem = "$false" -and title = specified should throw' {
+            { Add-VMImage @AddVMImageArgs -CreateGalleryItem $false -title 'testTitle' } |
+                Should Throw
+        }
+
+        It 'CreateGalleryItem = "$false" -and description = specified should throw' {
+            { Add-VMImage @AddVMImageArgs -CreateGalleryItem $false -description 'testdescription' } |
+                Should Throw
+        }
+    }
+}


### PR DESCRIPTION
- fixed CreateGalleryItem parameter type from string to bool 
- fixed overall indentation (removed tabs and corrected 3 space indent to 4 space overall
- added validations for resource group, storage account and container presence when function starts (in case of script cancel / exception on earlier run)
- added VM Image already exist check and bail out if so
- Changed write-host error messages and exit to write-error -erroraction stop for cancelled / failed download
- Added initial tests covering Module import, function export, parameter combination validation