### PR TITLE
Add MAS-CA01.azurestack.local to the trusted hosts

### DIFF
--- a/Connect/README.md
+++ b/Connect/README.md
@@ -45,6 +45,9 @@ Then connect your client computer as follows.
 # Create VPN connection entry for the current user
 Add-AzureStackVpnConnection -ServerAddress $natIp -Password $Password
 
+# Add Azure Stack MAS-CA01 to the trusted hosts on your client computer
+Set-Item wsman:\localhost\Client\TrustedHosts -Value "MAS-CA01.azurestack.local" -Concatenate 
+
 # Connect to the Azure Stack instance. This command can be used multiple times.
 Connect-AzureStackVpn -Password $Password
 ```

--- a/Infrastructure/AzureStack.Infra.psm1
+++ b/Infrastructure/AzureStack.Infra.psm1
@@ -45,7 +45,7 @@ Function LoginAzureStackAdminEnvironment {
     $powershellClientId = "0a7bdc5c-7b57-40be-9939-d4c5fc7cd417"
     $adminToken = Get-AzureStackToken -WarningAction Ignore -Authority $environment.ActiveDirectoryAuthority -Resource $environment.ActiveDirectoryServiceEndpointResourceId -AadTenantId $tenantID -ClientId $powershellClientId -Credential $azureStackCredential
     $adminSubscription = Get-AzureRMTenantSubscription -AdminUri $environment.ResourceManagerUrl -Token $admintoken -WarningAction Ignore
-    $subscription = $adminSubscription.SubscriptionId
+    $subscription = ($adminSubscription | Where-Object {$_.DisplayName -EQ "Default Provider Subscription"}).SubscriptionId
     $properties = @{
         ArmEndpoint = $environment.ResourceManagerUrl
         AdminToken = $adminToken


### PR DESCRIPTION
Add MAS-CA01.azurestack.local to the trusted hosts
- Connect-AzureStackVpn Error Message  
  [mas-ca01.azurestack.local] Connecting to remote server mas-ca01.azurestack.local failed with the following error message : The WinRM client cannot process the request. 
  If the authentication scheme is different from Kerberos, or if the client computer is not joined to a domain, then HTTPS transport must be used or the destination machine must be added to the TrustedHosts configuration setting. Use winrm.cmd to configure TrustedHosts. 
  Note that computers in the TrustedHosts list might not be authenticated. 
