### PR TITLE
Changes to support all clouds for Get-AADTenantGUID

### DIFF
--- a/Connect/AzureStack.Connect.psm1
+++ b/Connect/AzureStack.Connect.psm1
@@ -394,11 +394,16 @@ function Get-AADTenantGUID ()
 {
     param(
         [parameter(mandatory=$true, HelpMessage="AAD Directory Tenant <myaadtenant.onmicrosoft.com>")]
-	    [string] $AADTenantName = ""
+       [string] $AADTenantName = "",
+        [parameter(mandatory=$false, HelpMessage="Azure Cloud")]
+         [ValidateSet("AzureCloud","AzureChinaCloud","AzureUSGovernment","AzureGermanCloud")]
+        [string] $AzureCloud = "AzureCloud"
     )
-    $OauthMetadata = (wget -UseBasicParsing "https://login.microsoftonline.com/$AADTenantName/v2.0/.well-known/openid-configuration").Content | ConvertFrom-Json
+    $ADauth = (Get-AzureRmEnvironment -Name $AzureCloud).ActiveDirectoryAuthority
+    $endpt = "{0}{1}/.well-known/openid-configuration" -f $ADauth, $AADTenantName
+    $OauthMetadata = (wget -UseBasicParsing $endpt).Content | ConvertFrom-Json
     $AADid = $OauthMetadata.Issuer.Split('/')[3]
     $AADid
-}
+} 
 
 Export-ModuleMember Get-AADTenantGUID

--- a/Connect/AzureStack.Connect.psm1
+++ b/Connect/AzureStack.Connect.psm1
@@ -53,7 +53,8 @@ function Get-AzureStackAadTenant
     $Domain = ""
     try {
         $uriARMEndpoint = [System.Uri] $ArmEndpoint
-        $Domain = $ArmEndpoint.Split(".")[-2] + '.' + $ArmEndpoint.Split(".")[-1]
+        $i = $ArmEndpoint.IndexOf('.')
+        $Domain = ($ArmEndpoint.Remove(0,$i+1)).TrimEnd('/')
     }
     catch {
         Write-Error "The specified ARM endpoint was invalid"
@@ -101,7 +102,8 @@ function Add-AzureStackAzureRmEnvironment
     $Domain = ""
     try {
         $uriARMEndpoint = [System.Uri] $ArmEndpoint
-        $Domain = $ArmEndpoint.Split(".")[-3] + '.' + $ArmEndpoint.Split(".")[-2] + '.' + $ArmEndpoint.Split(".")[-1] 
+        $i = $ArmEndpoint.IndexOf('.')
+        $Domain = ($ArmEndpoint.Remove(0,$i+1)).TrimEnd('/')
     }
     catch {
         Write-Error "The specified ARM endpoint was invalid"
@@ -173,7 +175,8 @@ function Get-AzureStackNatServerAddress
     $Domain = ""
     try {
         $uriARMEndpoint = [System.Uri] $ArmEndpoint
-        $Domain = $ArmEndpoint.Split(".")[-2] + '.' + $ArmEndpoint.Split(".")[-1]
+        $i = $ArmEndpoint.IndexOf('.')
+        $Domain = ($ArmEndpoint.Remove(0,$i+1)).TrimEnd('/')
     }
     catch {
         Write-Error "The specified ARM endpoint was invalid"
@@ -268,7 +271,8 @@ function Connect-AzureStackVpn
     $Domain = ""
     try {
         $uriARMEndpoint = [System.Uri] $ArmEndpoint
-        $Domain = $ArmEndpoint.Split(".")[-2] + '.' + $ArmEndpoint.Split(".")[-1]
+        $i = $ArmEndpoint.IndexOf('.')
+        $Domain = ($ArmEndpoint.Remove(0,$i+1)).TrimEnd('/')
     }
     catch {
         Write-Error "The specified ARM endpoint was invalid"
@@ -353,7 +357,8 @@ function Get-AzureStackAdminSubTokenHeader
     $Domain = ""
     try {
         $uriARMEndpoint = [System.Uri] $ArmEndpoint
-        $Domain = $ArmEndpoint.Split(".")[-2] + '.' + $ArmEndpoint.Split(".")[-1]
+        $i = $ArmEndpoint.IndexOf('.')
+        $Domain = ($ArmEndpoint.Remove(0,$i+1)).TrimEnd('/')
     }
     catch {
         Write-Error "The specified ARM endpoint was invalid"


### PR DESCRIPTION
Changes to just Get-AADTenantGUID in Connect module to support all sovereign clouds, added additional param with a default value of AzureCloud and stopped using v2.0 endpoint.