### PR TITLE
Fixes for Compute Admin

### DIFF
--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -481,8 +481,12 @@ function New-Server2016VMImage {
             } catch {
                 Write-Error -ErrorRecord $_ -ErrorAction Stop
             } finally {
-                if (Test-Path -Path "$VHDDriveLetter`:\") {
-                    $VHDPath | Dismount-DiskImage 
+                $retryAttempts = 0;
+                while ((Test-Path -Path "$VHDDriveLetter`:\") -and ($retryAttempts -lt 5)) {
+                    Write-Verbose -Message "Attempting to dismount the VHD..."
+                    Get-DiskImage -ImagePath $VHDPath | Dismount-DiskImage
+                    $retryAttempts = $retryAttempts+1;
+                    sleep 1
                 }
                 if ($IsoMount) {
                     $IsoMount | Dismount-DiskImage       

--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -90,6 +90,16 @@ Function Add-VMImage{
         [bool] $CreateGalleryItem = $true
     )
 
+    if(!$ARMEndpoint.Contains('https://')){
+        if($ARMEndpoint.Contains('http://')){
+            $ARMEndpoint = $ARMEndpoint.Substring(7)
+            $ARMEndpoint = 'https://' + $ARMEndpoint
+
+        }else{
+            $ARMEndpoint = 'https://' + $ARMEndpoint
+        }
+    }
+
     if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('title'))
     {
         Write-Error -Message "The title parameter only applies to creating a gallery item." -ErrorAction Stop
@@ -321,6 +331,15 @@ Function Remove-VMImage{
 
     )
 
+    if(!$ARMEndpoint.Contains('https://')){
+        if($ARMEndpoint.Contains('http://')){
+            $ARMEndpoint = $ARMEndpoint.Substring(7)
+            $ARMEndpoint = 'https://' + $ARMEndpoint
+        }else{
+            $ARMEndpoint = 'https://' + $ARMEndpoint
+        }
+    }
+
     $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -ArmEndpoint $ArmEndpoint)
 
     $VMImageExists = $false
@@ -479,6 +498,12 @@ function New-Server2016VMImage {
         }
     }
     process {
+
+        Write-Verbose -Message "Checking ISO path for a valid ISO." -Verbose
+        if(!$IsoPath.ToLower().contains('.iso')){
+            Write-Error -Message "ISO path is not a valid ISO file." -ErrorAction Stop
+        }
+
         Write-Verbose -Message "Checking authorization against your Azure Stack environment" -Verbose
     
         $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -ArmEndpoint $ArmEndpoint -ErrorAction Stop)

--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -440,14 +440,15 @@ function New-Server2016VMImage {
                 }
                 Write-Verbose -Message "Preparing VHD"
 
-                $VHDDriveLetter = (Mount-VHD -Path  $VHDPath -Passthru |  `
-                get-disk -number {$_.DiskNumber} | `
+                Mount-DiskImage -ImagePath $VHDPath -Passthru
+                $disknum = (Get-DiskImage -ImagePath $VHDPath).Number
+                $VHDDriveLetter = (get-disk -number  $disknum| `
                 Initialize-Disk -PartitionStyle MBR -PassThru | `
-                New-Partition -UseMaximumSize -AssignDriveLetter:$False -MbrType IFS | `
+                New-Partition -UseMaximumSize -AssignDriveLetter:$False -IsActive:$true | `
                 Format-Volume -Confirm:$false -FileSystem NTFS -force | `
                 get-partition | `
                 Add-PartitionAccessPath -AssignDriveLetter -PassThru | `
-                get-volume).DriveLetter  
+                get-volume).DriveLetter
 
                 Write-Verbose -Message "VHD is mounted at drive letter: $VHDDriveLetter"
 

--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -266,7 +266,12 @@ Function Add-VMImage{
         $blob = $container| Set-AzureStorageBlobContent  –File $GalleryItem.FullName  –Blob $galleryItem.Name
         $galleryItemURI = '{0}{1}/{2}' -f $storageAccount.PrimaryEndpoints.Blob.AbsoluteUri, $containerName,$galleryItem.Name
 
-        Add-AzureRMGalleryItem -SubscriptionId $subscription -GalleryItemUri $galleryItemURI -ApiVersion 2015-04-01
+        
+        if((Get-Module AzureStack).Version -ge [System.Version] "1.2.9"){
+            Add-AzureRMGalleryItem -GalleryItemUri $galleryItemURI
+        }else{
+            Add-AzureRMGalleryItem -SubscriptionId $subscription -GalleryItemUri $galleryItemURI -ApiVersion 2015-04-01
+        }
 
         #cleanup
         Remove-Item $GalleryItem
@@ -354,7 +359,12 @@ Function Remove-VMImage{
         $name = "$offer$sku"
         #Remove periods so that the offer and sku can be retrieved from the Marketplace Item name
         $name =$name -replace "\.","-"
-        Get-AzureRMGalleryItem -ApiVersion 2015-04-01 | Where-Object {$_.Name -contains "$publisher.$name.$version"} | Remove-AzureRMGalleryItem -ApiVersion 2015-04-01
+        if((Get-Module AzureStack).Version -ge [System.Version] "1.2.9"){
+            Get-AzureRMGalleryItem | Where-Object {$_.Name -contains "$publisher.$name.$version"} | Remove-AzureRMGalleryItem 
+        }else{
+            Get-AzureRMGalleryItem -ApiVersion 2015-04-01 | Where-Object {$_.Name -contains "$publisher.$name.$version"} | Remove-AzureRMGalleryItem -ApiVersion 2015-04-01
+        }
+        
     }
 
 }

--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -100,13 +100,11 @@ Function Add-VMImage{
         }
     }
 
-    if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('title'))
-    {
+    if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('title')) {
         Write-Error -Message "The title parameter only applies to creating a gallery item." -ErrorAction Stop
     }
 
-    if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('description'))
-    {
+    if($CreateGalleryItem -eq $false -and $PSBoundParameters.ContainsKey('description')) {
         Write-Error -Message "The description parameter only applies to creating a gallery item." -ErrorAction Stop
     }
 
@@ -141,18 +139,15 @@ Function Add-VMImage{
         $container = New-AzureStorageContainer -Name $containerName -Permission Blob
     }
 
-    if(($pscmdlet.ParameterSetName -eq "VMImageFromLocal") -and (-not $VMImageAlreadyAvailable))
-    {
+    if(($pscmdlet.ParameterSetName -eq "VMImageFromLocal") -and (-not $VMImageAlreadyAvailable)) {
         $storageAccount.PrimaryEndpoints.Blob
         $script:osDiskName = Split-Path $osDiskLocalPath -Leaf
         $script:osDiskBlobURIFromLocal = '{0}{1}/{2}' -f $storageAccount.PrimaryEndpoints.Blob.AbsoluteUri, $containerName,$osDiskName
         Add-AzureRmVhd -Destination $osDiskBlobURIFromLocal -ResourceGroupName $resourceGroupName -LocalFilePath $osDiskLocalPath -OverWrite
 
         $script:dataDiskBlobURIsFromLocal = New-Object System.Collections.ArrayList
-        if ($PSBoundParameters.ContainsKey('dataDisksLocalPaths'))
-        {
-            foreach($dataDiskLocalPath in $dataDisksLocalPaths)
-            {
+        if ($PSBoundParameters.ContainsKey('dataDisksLocalPaths')) {
+            foreach($dataDiskLocalPath in $dataDisksLocalPaths) {
                 $dataDiskName = Split-Path $dataDiskLocalPath -Leaf
                 $dataDiskBlobURI = "https://$storageAccountName.blob.$Domain/$containerName/$dataDiskName"
                 $dataDiskBlobURIsFromLocal.Add($dataDiskBlobURI) 
@@ -169,35 +164,28 @@ Function Add-VMImage{
     #building platform image JSON
 
     #building osDisk json
-    if($pscmdlet.ParameterSetName -eq "VMImageFromLocal")
-    {
+    if($pscmdlet.ParameterSetName -eq "VMImageFromLocal") {
         $osDiskJSON = '"OsDisk":{"OsType":"'+ $osType + '","Uri":"'+$osDiskBlobURIFromLocal+'"}'
     }
-    else
-    {
+    else {
         $osDiskJSON = '"OsDisk":{"OsType":"'+ $osType + '","Uri":"'+$osDiskBlobURI+'"}'
     }
 
     #building details JSON
     $detailsJSON = ''
-    if ($PSBoundParameters.ContainsKey('billingPartNumber'))
-    {
+    if ($PSBoundParameters.ContainsKey('billingPartNumber')) {
         $detailsJSON = '"Details":{"BillingPartNumber":"' + $billingPartNumber+'"}'
     }
 
     #building dataDisk JSON
     $dataDisksJSON = ''
 
-    if($pscmdlet.ParameterSetName -eq "VMImageFromLocal")
-    {
-        if ($dataDiskBlobURIsFromLocal.Count -ne 0)
-        {
-             $dataDisksJSON = '"DataDisks":['
-             $i = 0
-             foreach($dataDiskBlobURI in $dataDiskBlobURIsFromLocal)
-             {
-                if($i -ne 0)
-                {
+    if($pscmdlet.ParameterSetName -eq "VMImageFromLocal") {
+        if ($dataDiskBlobURIsFromLocal.Count -ne 0) {
+            $dataDisksJSON = '"DataDisks":['
+            $i = 0
+            foreach($dataDiskBlobURI in $dataDiskBlobURIsFromLocal) {
+                if($i -ne 0) {
                     $dataDisksJSON = $dataDisksJSON +', '
                 }
 
@@ -205,21 +193,17 @@ Function Add-VMImage{
                 $dataDisksJSON = $dataDisksJSON + $newDataDisk;
             
                 ++$i
-             }
+            }
 
-             $dataDisksJSON = $dataDisksJSON +']'
-       }
+            $dataDisksJSON = $dataDisksJSON +']'
+        }
     }
-    else
-    {
-        if ($dataDiskBlobURIs.Count -ne 0)
-        {
+    else {
+        if ($dataDiskBlobURIs.Count -ne 0) {
             $dataDisksJSON = '"DataDisks":['
             $i = 0
-            foreach($dataDiskBlobURI in $dataDiskBlobURIs)
-            {
-                if($i -ne 0)
-                {
+            foreach($dataDiskBlobURI in $dataDiskBlobURIs) {
+                if($i -ne 0) {
                     $dataDisksJSON = $dataDisksJSON +', '
                 }
 
@@ -237,13 +221,11 @@ Function Add-VMImage{
 
     $propertyBody = $osDiskJSON 
 
-    if(![string]::IsNullOrEmpty($dataDisksJson))
-    {
+    if(![string]::IsNullOrEmpty($dataDisksJson)) {
         $propertyBody = $propertyBody + ', ' + $dataDisksJson
     }
 
-    if(![string]::IsNullOrEmpty($detailsJson))
-    {
+    if(![string]::IsNullOrEmpty($detailsJson)) {
         $propertyBody = $propertyBody + ', ' + $detailsJson
     }
 
@@ -256,15 +238,12 @@ Function Add-VMImage{
     $platformImage = Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
 
     $downloadingStatusCheckCount = 0
-    while($platformImage.Properties.ProvisioningState -ne 'Succeeded')
-    {
-        if($platformImage.Properties.ProvisioningState -eq 'Failed')
-        {
+    while($platformImage.Properties.ProvisioningState -ne 'Succeeded') {
+        if($platformImage.Properties.ProvisioningState -eq 'Failed') {
             Write-Error -Message "VM image download failed." -ErrorAction Stop
         }
 
-        if($platformImage.Properties.ProvisioningState -eq 'Canceled')
-        {
+        if($platformImage.Properties.ProvisioningState -eq 'Canceled') {
             Write-Error -Message "VM image download was canceled." -ErrorAction Stop
         }
 
@@ -278,8 +257,7 @@ Function Add-VMImage{
         $platformImage = Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
     }
 
-    if($CreateGalleryItem -eq $true -And $platformImage.Properties.ProvisioningState -eq 'Succeeded')
-    {
+    if($CreateGalleryItem -eq $true -And $platformImage.Properties.ProvisioningState -eq 'Succeeded') {
         #reaquire storage account context
         Set-AzureRmCurrentStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName
         $container = Get-AzureStorageContainer -Name $containerName -ErrorAction SilentlyContinue
@@ -427,7 +405,7 @@ function New-Server2016VMImage {
             )
             $tmpfile = New-TemporaryFile
             "create vdisk FILE=`"$VHDPath`" TYPE=EXPANDABLE MAXIMUM=$VHDSizeInMB" | 
-                Out-File -FilePath $tmpfile.FullName -Encoding ascii
+            Out-File -FilePath $tmpfile.FullName -Encoding ascii
 
             Write-Verbose -Message "Creating VHD at: $VHDPath of size: $VHDSizeInMB MB"
             diskpart.exe /s $tmpfile.FullName | Out-Null
@@ -595,13 +573,11 @@ function New-Server2016VMImage {
                     Write-Verbose -Message "Server Core VHD already found."
                 }
 
-                if ($CreateGalleryItem)
-                {
+                if ($CreateGalleryItem) {
                     $description = "This evaluation image should not be used for production workloads."
                     Add-VMImage -sku $sku -osDiskLocalPath $ImagePath @PublishArguments -title "Windows Server 2016 Datacenter Core Eval" -description $description -CreateGalleryItem $CreateGalleryItem
                 }
-                else
-                {
+                else {
                     Add-VMImage -sku $sku -osDiskLocalPath $ImagePath @PublishArguments -CreateGalleryItem $CreateGalleryItem
                 }
             } catch {
@@ -627,13 +603,11 @@ function New-Server2016VMImage {
                 }else{
                     Write-Verbose -Message "Server Full VHD already found."
                 }
-                if ($CreateGalleryItem)
-                {
+                if ($CreateGalleryItem) {
                     $description = "This evaluation image should not be used for production workloads."
                     Add-VMImage -sku $sku -osDiskLocalPath $ImagePath @PublishArguments -title "Windows Server 2016 Datacenter Eval" -description $description -CreateGalleryItem $CreateGalleryItem
                 }
-                else
-                {
+                else {
                     Add-VMImage -sku $sku -osDiskLocalPath $ImagePath @PublishArguments -CreateGalleryItem $CreateGalleryItem
                 }
             } catch {
@@ -662,76 +636,88 @@ Function CreateGalleyItem{
         [string] $title,
         [string] $description
     )
-        $workdir = '{0}\{1}' -f $env:TEMP, [System.Guid]::NewGuid().ToString()
-        New-Item $workdir -ItemType Directory | Out-Null
-        $basePath = (Get-Module AzureStack.ComputeAdmin).ModuleBase
-        $compressedGalleryItemPath = Join-Path $basePath 'CustomizedVMGalleryItem.azpkg'
-        Copy-Item -Path $compressedGalleryItemPath -Destination "$workdir\CustomizedVMGalleryItem.zip"
-        $extractedGalleryItemPath = Join-Path $workdir 'galleryItem'
-        New-Item -ItemType directory -Path $extractedGalleryItemPath | Out-Null
-        expand-archive -Path "$workdir\CustomizedVMGalleryItem.zip" -DestinationPath $extractedGalleryItemPath -Force
+    $workdir = '{0}\{1}' -f $env:TEMP, [System.Guid]::NewGuid().ToString()
+    New-Item $workdir -ItemType Directory | Out-Null
+    $basePath = (Get-Module AzureStack.ComputeAdmin).ModuleBase
+    $compressedGalleryItemPath = Join-Path $basePath 'CustomizedVMGalleryItem.azpkg'
+    Copy-Item -Path $compressedGalleryItemPath -Destination "$workdir\CustomizedVMGalleryItem.zip"
+    $extractedGalleryItemPath = Join-Path $workdir 'galleryItem'
+    New-Item -ItemType directory -Path $extractedGalleryItemPath | Out-Null
+    expand-archive -Path "$workdir\CustomizedVMGalleryItem.zip" -DestinationPath $extractedGalleryItemPath -Force
         
-        $extractedName = 'MarketplaceItem.zip'
-        Invoke-WebRequest -Uri http://www.aka.ms/azurestackmarketplaceitem -OutFile "$workdir\MarketplaceItem.zip" 
-        Expand-Archive -Path "$workdir\MarketplaceItem.zip" -DestinationPath $workdir -Force
-
-#region UIDef
-        $createUIDefinitionPath = Join-Path $extractedGalleryItemPath 'DeploymentTemplates\CreateUIDefinition.json'
-        $JSON = Get-Content $createUIDefinitionPath | Out-String | ConvertFrom-Json
-        $JSON.parameters.osPlatform = $osType
-        $JSON.parameters.imageReference.publisher = $publisher
-        $JSON.parameters.imageReference.offer = $offer
-        $JSON.parameters.imageReference.sku = $sku
-        $JSON | ConvertTo-Json -Compress| set-content $createUIDefinitionPath
-#endregion
-
-#region Manifest
-        $manifestPath = Join-Path $extractedGalleryItemPath 'manifest.json'
-        $JSON = Get-Content $manifestPath | Out-String | ConvertFrom-Json
-
-        if (!$title)
-        {
-            $title = "{0}-{1}-{2}" -f $publisher, $offer, $sku
+    $extractedName = 'MarketplaceItem.zip'
+    $retryAttempts = 1
+    while ($retryAttempts -le 5) {
+        try {
+            Write-Verbose -Message "Downloading Azure Stack Marketplace Item Generator Attempt $retryAttempts" -Verbose
+            Invoke-WebRequest -Uri http://www.aka.ms/azurestackmarketplaceitem -OutFile "$workdir\MarketplaceItem.zip" 
+            break
         }
-        $name = "$offer$sku"
-        #Remove periods so that the offer and sku can be part of the MarketplaceItem name 
-        $name =$name -replace "\.","-"
-        $JSON.name = $name
-        $JSON.publisher = $publisher
-        $JSON.version = $version
-        $JSON.displayName = $title
-        $JSON.publisherDisplayName = $publisher
-        $JSON.publisherLegalName = $publisher
-        $JSON | ConvertTo-Json -Compress| set-content $manifestPath
-
-#endregion
-
-#region Strings
-        if (!$description)
-        {
-            $description = "Create a virtual machine from a VM image. Publisher: {0}, Offer: {1}, Sku:{2}, Version: {3}" -f $publisher, $offer, $sku, $version
+        catch {
+            $retryAttempts = $retryAttempts + 1
+            if($retryAttempts -ge 5){
+                Write-Error "Failed to download Azure Stack Marketplace Item Generator" -ErrorAction Stop
+            }
         }
-        $stringsPath = Join-Path $extractedGalleryItemPath 'strings\resources.resjson'
-        $JSON = Get-Content $stringsPath | Out-String | ConvertFrom-Json
-        $JSON.longSummary = $description
-        $JSON.description = $description
-        $JSON.summary = $description
-        $JSON | ConvertTo-Json -Compress | set-content $stringsPath
-#endregion
- 
-        $extractedGalleryPackagerExePath = Join-Path $workdir "Azure Stack Marketplace Item Generator and Sample\AzureGalleryPackageGenerator"
-        $galleryItemName = $publisher + "." + $name + "." + $version + ".azpkg"
-        $currentPath = $pwd
-        cd $extractedGalleryPackagerExePath
-        .\AzureGalleryPackager.exe package -m $manifestPath -o $workdir
-        cd $currentPath
-
-        #cleanup
-        Remove-Item $extractedGalleryItemPath -Recurse -Force
-        Remove-Item "$workdir\Azure Stack Marketplace Item Generator and Sample" -Recurse -Force
-        Remove-Item "$workdir\CustomizedVMGalleryItem.zip"
-        Remove-Item "$workdir\MarketplaceItem.zip"
-        $azpkg = '{0}\{1}' -f $workdir, $galleryItemName
-        return Get-Item -LiteralPath $azpkg
     }
+
+    Expand-Archive -Path "$workdir\MarketplaceItem.zip" -DestinationPath $workdir -Force
+
+    #region UIDef
+    $createUIDefinitionPath = Join-Path $extractedGalleryItemPath 'DeploymentTemplates\CreateUIDefinition.json'
+    $JSON = Get-Content $createUIDefinitionPath | Out-String | ConvertFrom-Json
+    $JSON.parameters.osPlatform = $osType
+    $JSON.parameters.imageReference.publisher = $publisher
+    $JSON.parameters.imageReference.offer = $offer
+    $JSON.parameters.imageReference.sku = $sku
+    $JSON | ConvertTo-Json -Compress| set-content $createUIDefinitionPath
+    #endregion
+
+    #region Manifest
+    $manifestPath = Join-Path $extractedGalleryItemPath 'manifest.json'
+    $JSON = Get-Content $manifestPath | Out-String | ConvertFrom-Json
+
+    if (!$title) {
+        $title = "{0}-{1}-{2}" -f $publisher, $offer, $sku
+    }
+    $name = "$offer$sku"
+    #Remove periods so that the offer and sku can be part of the MarketplaceItem name 
+    $name =$name -replace "\.","-"
+    $JSON.name = $name
+    $JSON.publisher = $publisher
+    $JSON.version = $version
+    $JSON.displayName = $title
+    $JSON.publisherDisplayName = $publisher
+    $JSON.publisherLegalName = $publisher
+    $JSON | ConvertTo-Json -Compress| set-content $manifestPath
+
+    #endregion
+
+    #region Strings
+    if (!$description) {
+        $description = "Create a virtual machine from a VM image. Publisher: {0}, Offer: {1}, Sku:{2}, Version: {3}" -f $publisher, $offer, $sku, $version
+    }
+    $stringsPath = Join-Path $extractedGalleryItemPath 'strings\resources.resjson'
+    $JSON = Get-Content $stringsPath | Out-String | ConvertFrom-Json
+    $JSON.longSummary = $description
+    $JSON.description = $description
+    $JSON.summary = $description
+    $JSON | ConvertTo-Json -Compress | set-content $stringsPath
+    #endregion
+ 
+    $extractedGalleryPackagerExePath = Join-Path $workdir "Azure Stack Marketplace Item Generator and Sample\AzureGalleryPackageGenerator"
+    $galleryItemName = $publisher + "." + $name + "." + $version + ".azpkg"
+    $currentPath = $pwd
+    cd $extractedGalleryPackagerExePath
+    .\AzureGalleryPackager.exe package -m $manifestPath -o $workdir
+    cd $currentPath
+
+    #cleanup
+    Remove-Item $extractedGalleryItemPath -Recurse -Force
+    Remove-Item "$workdir\Azure Stack Marketplace Item Generator and Sample" -Recurse -Force
+    Remove-Item "$workdir\CustomizedVMGalleryItem.zip"
+    Remove-Item "$workdir\MarketplaceItem.zip"
+    $azpkg = '{0}\{1}' -f $workdir, $galleryItemName
+    return Get-Item -LiteralPath $azpkg
+}
 

--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -257,11 +257,11 @@ Function Add-VMImage{
         $platformImage = Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
     }
 
-    if($CreateGalleryItem -eq $true -And $platformImage.Properties.ProvisioningState -eq 'Succeeded') {
-        #reaquire storage account context
-        Set-AzureRmCurrentStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName
-        $container = Get-AzureStorageContainer -Name $containerName -ErrorAction SilentlyContinue
+    #reaquire storage account context
+    Set-AzureRmCurrentStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName
+    $container = Get-AzureStorageContainer -Name $containerName -ErrorAction SilentlyContinue
 
+    if($CreateGalleryItem -eq $true -And $platformImage.Properties.ProvisioningState -eq 'Succeeded') {
         $GalleryItem = CreateGalleyItem -publisher $publisher -offer $offer -sku $sku -version $version -osType $osType -title $title -description $description 
         $blob = $container| Set-AzureStorageBlobContent  –File $GalleryItem.FullName  –Blob $galleryItem.Name
         $galleryItemURI = '{0}{1}/{2}' -f $storageAccount.PrimaryEndpoints.Blob.AbsoluteUri, $containerName,$galleryItem.Name

--- a/ComputeAdmin/README.md
+++ b/ComputeAdmin/README.md
@@ -20,7 +20,7 @@ Adding a VM Image requires that you obtain the GUID value of your Directory Tena
 $aadTenant = Get-AADTenantGUID -AADTenantName "<myaadtenant>.onmicrosoft.com" 
 ```
 
-Otherwise, it can be retrieved directly from your Azure Stack deployment. First, add your host to the list of TrustedHosts:
+Otherwise, it can be retrieved directly from your Azure Stack deployment. This method can also be used for AD FS. First, add your host to the list of TrustedHosts:
 ```powershell
 Set-Item wsman:\localhost\Client\TrustedHosts -Value "<Azure Stack host address>" -Concatenate
 ```
@@ -41,6 +41,8 @@ An example usage is the following:
 $ISOPath = "<Path to ISO>"
 New-Server2016VMImage -ISOPath $ISOPath -TenantId $aadTenant  
 ```
+
+This command may show a popup prompt that can be ignored without issue.
 
 To ensure that the Windows Server 2016 VM Image has the latest cumulative update, provide the -IncludeLatestCU parameter.
 

--- a/Connect/AzureStack.Connect.psm1
+++ b/Connect/AzureStack.Connect.psm1
@@ -381,12 +381,17 @@ function Get-AzureStackAdminSubTokenHeader
 
     $powershellClientId = "0a7bdc5c-7b57-40be-9939-d4c5fc7cd417"
 
+    $savedWarningPreference = $WarningPreference
+    $WarningPreference = 'SilentlyContinue' 
+
     $adminToken = Get-AzureStackToken `
     -Authority $authority `
     -Resource $activeDirectoryServiceEndpointResourceId `
     -AadTenantId $tenantID `
     -ClientId $powershellClientId `
-    -Credential $azureStackCredentials
+    -Credential $azureStackCredentials 
+
+    $WarningPreference = $savedWarningPreference
 
     $headers = @{ Authorization = ("Bearer $adminToken") }
     


### PR DESCRIPTION
1.	Reverting to Add-AzureRMVHD – 
a.	I found the reason that Set-AzureRMBlobContent was faster. It turns out that the latter method leaves the VHD as dynamic when it makes its way into the PIR. This can cause a number of issues later on with VM lifecycle operations since CRP does not support dynamic disks. Add-AzureRMVHD implicitly makes it fixed by turning into a Page Blob. 
2.	Stopping on credential validation errors immediately 
a.	This helps us prevent users from getting too far before we catch simple issues like ARM Endpoint parameters and creds mistakes
3.	Token refreshing on the download portion so that we don’t get issues with the token timing out 
a.	Tokens refresh every 5 minutes on the download
4.	Fixed minor issues with Remove-VMImage
5.	Idempotency Fixes (major chunks for now) 
a.	Check for the existence of the VHD – this suggests that the last state was a download or upload error (skip VHD creation)
b.	Check for the existence of the VM Image – this suggests the VM Image made its way into the PIR, but that the Marketplace item component failed (skip VHD creation and upload/download)
6.	Added validation to check that the ARM endpoint specified is valid – catches typos or bad endpoint for environment
7.	Added retry logic for downloading Marketplace item pre-reqs in case of connection dropping
8.	Added a stronger check for idempotent logic to get around the time it took for the previous check to work as expected


