### PR TITLE
Update repo Readme.mds to use 1.2.9 Version & Remove unsupported parameters

### DIFF
--- a/CanaryValidator/Canary.Tests.ps1
+++ b/CanaryValidator/Canary.Tests.ps1
@@ -180,7 +180,13 @@ while ($runCount -le $NumberOfIterations)
             $asToken = NewAzureStackToken -AADTenantId $AADTenantId -EnvironmentDomainFQDN $EnvironmentDomainFQDN -Credentials $ServiceAdminCredentials -ArmEndPoint $AdminArmEndpoint
             $defaultSubscription = Get-AzureRmSubscription -SubscriptionName "Default Provider Subscription" -ErrorAction Stop            
             $asCanaryQuotas = NewAzureStackDefaultQuotas -ResourceLocation $ResourceLocation -SubscriptionId $defaultSubscription.SubscriptionId -AADTenantID $AADTenantID -EnvironmentDomainFQDN $EnvironmentDomainFQDN -Credentials $ServiceAdminCredentials -ArmEndPoint $AdminArmEndPoint
-            New-AzureRMPlan -Name $tenantPlanName -DisplayName $tenantPlanName -ArmLocation $ResourceLocation -ResourceGroup $subscriptionRGName -SubscriptionId $defaultSubscription.SubscriptionId -AdminUri $AdminArmEndPoint -Token $asToken -QuotaIds $asCanaryQuotas -ErrorAction Stop
+            if((Get-Module AzureStack).Version -ge [System.Version] "1.2.9")
+            { 
+                New-AzureRMPlan -Name $tenantPlanName -DisplayName $tenantPlanName -ArmLocation $ResourceLocation -ResourceGroup $subscriptionRGName -QuotaIds $asCanaryQuotas -ErrorAction Stop
+            }
+            else {
+             New-AzureRMPlan -Name $tenantPlanName -DisplayName $tenantPlanName -ArmLocation $ResourceLocation -ResourceGroup $subscriptionRGName -SubscriptionId $defaultSubscription.SubscriptionId -AdminUri $AdminArmEndPoint -Token $asToken -QuotaIds $asCanaryQuotas -ErrorAction Stop               
+            }
         }
 
         Invoke-Usecase -Name 'CreateTenantOffer' -Description "Create a tenant offer" -UsecaseBlock `

--- a/CanaryValidator/README.md
+++ b/CanaryValidator/README.md
@@ -14,8 +14,9 @@ cd AzureStack-Tools-master\CanaryValidator
 
 # To execute Canary as Tenant Administrator
 ```powershell
-# Install-Module AzureRM -RequiredVersion 1.2.8 -Force
-# Install-Module AzureStack -RequiredVersion 1.2.8 -Force
+# Install-Module -Name 'AzureRm.Bootstrapper' -Force
+# Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+# Install-Module AzureStack -RequiredVersion 1.2.9 -Force
 $TenantAdminCreds =  New-Object System.Management.Automation.PSCredential "<Tenant Admin username>", (ConvertTo-SecureString "<Tenant Admin password>" -AsPlainText -Force)
 $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Service Admin username>", (ConvertTo-SecureString "<Service Admin password>" -AsPlainText -Force)
 .\Canary.Tests.ps1  -AADTenantID "<TenantID from Azure Active Directory>"  -AdminArmEndpoint "<Administrative ARM endpoint>" -ServiceAdminCredentials $ServiceAdminCreds -TenantArmEndpoint "<Tenant ARM endpoint>" -TenantAdminCredentials $TenantAdminCreds
@@ -23,8 +24,9 @@ $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Ser
 
 # To execute Canary as Service Administrator
 ```powershell
-# Install-Module AzureRM -RequiredVersion 1.2.8 -Force
-# Install-Module AzureStack -RequiredVersion 1.2.8 -Force
+# Install-Module -Name 'AzureRm.Bootstrapper' -Force
+# Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+# Install-Module AzureStack -RequiredVersion 1.2.9 -Force
 $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Service Admin username>", (ConvertTo-SecureString "<Service Admin password>" -AsPlainText -Force)
 .\Canary.Tests.ps1 -AADTenantID "<TenantID from Azure Active Directory>"  -AdminArmEndpoint "<Administrative ARM endpoint>"  -ServiceAdminCredentials $ServiceAdminCreds -TenantArmEndpoint "<Tenant ARM endpoint>" 
 ```

--- a/ComputeAdmin/README.md
+++ b/ComputeAdmin/README.md
@@ -4,8 +4,9 @@ Instructions below are relative to the .\ComputeAdmin folder of the [AzureStack-
 Make sure you have the following module prerequisites installed:
 
 ```powershell
-Install-Module -Name AzureRM -RequiredVersion 1.2.8 -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.8 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
+Install-Module -Name AzureStack -RequiredVersion 1.2.9 -Scope CurrentUser
 ```
 Then make sure the following modules are imported:
 

--- a/Connect/README.md
+++ b/Connect/README.md
@@ -1,8 +1,9 @@
 As a prerequisite, make sure that you installed the correct PowerShell modules and versions:
 
 ```powershell
-Install-Module -Name AzureRM -RequiredVersion 1.2.8 -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.8 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
+Install-Module -Name AzureStack -RequiredVersion 1.2.9 -Scope CurrentUser
 ```
 
 This tool set allows you to connect to an Azure Stack PoC (Proof of Concept) instance from an external personal laptop. You can then access the portal or log into that environment via PowerShell. 

--- a/Identity/README.md
+++ b/Identity/README.md
@@ -1,8 +1,9 @@
 # Azure Stack Identity
 
 ```powershell
-Install-Module -Name AzureRM -RequiredVersion 1.2.8 -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.8 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
+Install-Module -Name AzureStack -RequiredVersion 1.2.9 -Scope CurrentUser
 ```
 Then make sure the following modules are imported:
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ To use these tools, obtain Azure Stack compatible Azure PowerShell module. Unles
 For PowerShell, install the following:
 
 ```powershell
-Install-Module -Name AzureRM -RequiredVersion 1.2.8 -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.8 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
+Install-Module -Name AzureStack -RequiredVersion 1.2.9 -Scope CurrentUser
 ```
 
 Obtain the tools by cloning the git repository.

--- a/ServiceAdmin/AzureStack.ServiceAdmin.psm1
+++ b/ServiceAdmin/AzureStack.ServiceAdmin.psm1
@@ -44,7 +44,13 @@ function New-AzSTenantOfferAndQuotas
     New-AzureRmResourceGroup -Name $Name -Location $Location -ErrorAction Stop
 
     Write-Verbose "Creating plan..." -Verbose
-    $plan = New-AzureRMPlan -Name $Name -DisplayName $Name -ArmLocation $Location -ResourceGroup $Name -SubscriptionId $subscription -QuotaIds $Quotas
+    if((Get-Module AzureStack).Version -ge [System.Version] "1.2.9")
+    {
+        $plan = New-AzureRMPlan -Name $Name -DisplayName $Name -ArmLocation $Location -ResourceGroup $Name -QuotaIds $Quotas
+    }
+    else {
+        $plan = New-AzureRMPlan -Name $Name -DisplayName $Name -ArmLocation $Location -ResourceGroup $Name -SubscriptionId $subscription -QuotaIds $Quotas        
+    }
 
     Write-Verbose "Creating public offer..." -Verbose
     $offer = New-AzureRMOffer -Name $Name -DisplayName $Name -State Public -BasePlanIds @($plan.Id) -ArmLocation $Location -ResourceGroup $Name

--- a/ServiceAdmin/AzureStack.ServiceAdmin.psm1
+++ b/ServiceAdmin/AzureStack.ServiceAdmin.psm1
@@ -44,13 +44,7 @@ function New-AzSTenantOfferAndQuotas
     New-AzureRmResourceGroup -Name $Name -Location $Location -ErrorAction Stop
 
     Write-Verbose "Creating plan..." -Verbose
-    if((Get-Module AzureStack).Version -ge [System.Version] "1.2.9")
-    {
-        $plan = New-AzureRMPlan -Name $Name -DisplayName $Name -ArmLocation $Location -ResourceGroup $Name -QuotaIds $Quotas
-    }
-    else {
-        $plan = New-AzureRMPlan -Name $Name -DisplayName $Name -ArmLocation $Location -ResourceGroup $Name -SubscriptionId $subscription -QuotaIds $Quotas        
-    }
+    $plan = New-AzureRMPlan -Name $Name -DisplayName $Name -ArmLocation $Location -ResourceGroup $Name -QuotaIds $Quotas
 
     Write-Verbose "Creating public offer..." -Verbose
     $offer = New-AzureRMOffer -Name $Name -DisplayName $Name -State Public -BasePlanIds @($plan.Id) -ArmLocation $Location -ResourceGroup $Name

--- a/ServiceAdmin/README.md
+++ b/ServiceAdmin/README.md
@@ -5,8 +5,9 @@ Instructions below are relative to the .\ServiceAdmin folder of the [AzureStack-
 Make sure you have the following module prerequisites installed:
 
 ```powershell
-Install-Module -Name AzureRM -RequiredVersion 1.2.8 -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.8 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
+Install-Module -Name AzureStack -RequiredVersion 1.2.9 -Scope CurrentUser
 ```
 Then make sure the following modules are imported:
 


### PR DESCRIPTION
1. Update Readme.mds to use AzureStack version 1.2.9
2. Update Readme.mds to use API version profiles to install AzureRm modules
3. Update AzureStack Admin cmdlets to remove unsupported parameters like 'SubscriptionId'