### PR TITLE
Refactor cmdlets to use AzureRm environment context

### DIFF
--- a/ComputeAdmin/README.md
+++ b/ComputeAdmin/README.md
@@ -35,14 +35,14 @@ $TenantID = Get-DirectoryTenantID -ADFS -EnvironmentName AzureStackAdmin
 
 ## Add the WS2016 Evaluation VM Image 
 
-The New-Server2016VMImage allows you to add a Windows Server 2016 Evaluation VM Image to your Azure Stack Marketplace. 
+The New-AzSServer2016VMImage allows you to add a Windows Server 2016 Evaluation VM Image to your Azure Stack Marketplace. 
 
 As a prerequisite, you need to obtain the Windows Server 2016 Evaluation ISO which can be found [here](https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2016).
 
 An example usage is the following:
 ```powershell
 $ISOPath = "<Path to ISO>"
-New-Server2016VMImage -ISOPath $ISOPath -TenantId $TenantID -EnvironmentName "AzureStackAdmin"
+New-AzSServer2016VMImage -ISOPath $ISOPath
 ```
 Please make sure to specify the correct administrator ARM endpoint for your environment.
 
@@ -74,10 +74,8 @@ Add-AzureStackAzureRmEnvironment -Name "AzureStackAdmin" -ArmEndpoint "https://a
 ```
 
 ```powershell
-Add-VMImage -publisher "Canonical" -offer "UbuntuServer" -sku "14.04.3-LTS" -version "1.0.0" -osType Linux -osDiskLocalPath 'C:\Users\<me>\Desktop\UbuntuServer.vhd' -tenantID <GUID AADTenant> -EnvironmentName "AzureStackAdmin"
+Add-VMImage -publisher "Canonical" -offer "UbuntuServer" -sku "14.04.3-LTS" -version "1.0.0" -osType Linux -osDiskLocalPath 'C:\Users\<me>\Desktop\UbuntuServer.vhd'
 ```
-
-Note: The cmdlet requests credentials for adding the VM image. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com, to the prompt.  
 
 The command does the following:
 - Authenticates to the Azure Stack environment
@@ -97,7 +95,7 @@ Add-AzureStackAzureRmEnvironment -Name "AzureStackAdmin" -ArmEndpoint "https://a
 ```
 
 ```powershell
-Remove-VMImage -publisher "Canonical" -offer "UbuntuServer" -sku "14.04.3-LTS" -version "1.0.0" -tenantID <GUID AADTenant> -EnvironmentName "AzureStackAdmin"
+Remove-VMImage -publisher "Canonical" -offer "UbuntuServer" -sku "14.04.3-LTS" -version "1.0.0"
 ```
 
 Note: This cmdlet will remove the associated Marketplace item unless the -KeepMarketplaceItem parameter is specified.
@@ -112,7 +110,7 @@ An example usage is the following:
 
 ```powershell
 $path = "<Path to vm extension zip>"
-Add-VMExtension -publisher "Publisher" -type "Type" -version "1.0.0.0" -extensionLocalPath $path -osType Windows -tenantID $TenantID -azureStackCredentials $azureStackCredentials -EnvironmentName "AzureStackAdmin"
+Add-VMExtension -publisher "Publisher" -type "Type" -version "1.0.0.0" -extensionLocalPath $path -osType Windows
 ```
 
 
@@ -126,14 +124,14 @@ Add-AzureStackAzureRmEnvironment -Name "AzureStackAdmin" -ArmEndpoint "https://a
 Run the below command to remove an uploaded VM extension.
 
 ```powershell
-Remove-VMExtension -publisher "Publisher" -type "Type" -version "1.0.0.0" -osType Windows -tenantID $TenantID -azureStackCredentials $azureStackCredentials -EnvironmentName "AzureStackAdmin"
+Remove-VMExtension -publisher "Publisher" -type "Type" -version "1.0.0.0" -osType Windows
 ```
 
 ## VM Scale Set gallery item
 
 VM Scale Set allows deployment of multi-VM collections. To add a gallery item with VM Scale Set:
 
-1. Add evaluation Windows Server 2016 image using New-Server2016VMImage as described above.
+1. Add evaluation Windows Server 2016 image using New-AzSServer2016VMImage as described above.
 
 2. For linux support, download Ubuntu Server 16.04 and add it using Add-VmImage with the following parameters -publisher "Canonical" -offer "UbuntuServer" -sku "16.04-LTS"
 

--- a/ComputeAdmin/Tests/ComputeAdmin.Tests.ps1
+++ b/ComputeAdmin/Tests/ComputeAdmin.Tests.ps1
@@ -11,13 +11,13 @@ Describe $script:ModuleName {
                 Should Not Be $null
         }
 
-        It 'Add-VMImage should be exported' {
-            Get-Command -Name Add-VMImage -ErrorAction SilentlyContinue | 
+        It 'Add-AzSVMImage should be exported' {
+            Get-Command -Name Add-AzSVMImage -ErrorAction SilentlyContinue | 
                 Should Not Be $null
         }
 
-        It 'Remove-VMImage should be exported' {
-            Get-Command -Name Remove-VMImage -ErrorAction SilentlyContinue | 
+        It 'Remove-AzSVMImage should be exported' {
+            Get-Command -Name Remove-AzSVMImage -ErrorAction SilentlyContinue | 
                 Should Not Be $null
         }
     }
@@ -59,38 +59,38 @@ InModuleScope $script:ModuleName {
 
     Describe 'ComputeAdmin - Functional Tests' {
         It 'CreateGalleryItem = "$false" -and title = specified should throw' {
-            { Add-VMImage -publisher $publisher -offer $offer -sku $sku -version $version -osType $osType -osDiskLocalPath $osDiskPath -tenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredential $stackLoginCreds -CreateGalleryItem $false -title 'testTitle' } |
+            { Add-AzSVMImage -publisher $publisher -offer $offer -sku $sku -version $version -osType $osType -osDiskLocalPath $osDiskPath -CreateGalleryItem $false -title 'testTitle' } |
                 Should Throw
         }
 
         It 'CreateGalleryItem = "$false" -and description = specified should throw' {
-            { Add-VMImage -publisher $publisher -offer $offer -sku $sku -version $version -osType $osType -osDiskLocalPath $osDiskPath -tenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredential $stackLoginCreds -CreateGalleryItem $false -title 'testTitle'  -CreateGalleryItem $false -description 'testdescription' } | Should Throw
+            { Add-AzSVMImage -publisher $publisher -offer $offer -sku $sku -version $version -osType $osType -osDiskLocalPath $osDiskPath -CreateGalleryItem $false -title 'testTitle'  -CreateGalleryItem $false -description 'testdescription' } | Should Throw
         }
 
-        It 'Add-VMImage via local path and upload to storage account should succeed' {
-            { Add-VMImage -publisher $publisher -offer $offer -sku $sku -version $version -osType $osType -osDiskLocalPath $osDiskPath -tenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredential $stackLoginCreds -CreateGalleryItem $false } |
+        It 'Add-AzSVMImage via local path and upload to storage account should succeed' {
+            { Add-AzSVMImage -publisher $publisher -offer $offer -sku $sku -version $version -osType $osType -osDiskLocalPath $osDiskPath -CreateGalleryItem $false } |
                 Should Not Throw
         }
 
-        It 'Remove-VMImage should successfully remove added VM Image' {
-            { Remove-VMImage -publisher $publisher -offer $offer -sku $sku -version $version -tenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredential $stackLoginCreds} |
+        It 'Remove-AzSVMImage should successfully remove added VM Image' {
+            { Remove-AzSVMImage -publisher $publisher -offer $offer -sku $sku -version $version} |
                 Should Not Throw
         }
 
-        It 'Add-VMImage via local path and upload to storage account with gallery item should succeed' {
-            { Add-VMImage -publisher $publisher -offer $offer -sku $gallerySku -version $version -osType $osType -osDiskLocalPath $osDiskPath -tenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredential $stackLoginCreds } |
+        It 'Add-AzSVMImage via local path and upload to storage account with gallery item should succeed' {
+            { Add-AzSVMImage -publisher $publisher -offer $offer -sku $gallerySku -version $version -osType $osType -osDiskLocalPath $osDiskPath } |
                 Should Not Throw
         }
 
-        It 'Remove-VMImage and Removing Marketplace Item should successfully complete' {
+        It 'Remove-AzSVMImage and Removing Marketplace Item should successfully complete' {
             { 
-                Remove-VMImage -publisher $publisher -offer $offer -sku $gallerySku -version $version -tenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredential $stackLoginCreds
+                Remove-AzSVMImage -publisher $publisher -offer $offer -sku $gallerySku -version $version
                 Get-AzureRMGalleryItem | Where-Object {$_.Name -contains "$publisher.$offer$gallerySku.$version"} | Remove-AzureRMGalleryItem 
             } | Should Not Throw
         }
 
         It 'Adding Ubuntu Linux 16.04 Image and Marketplace Item Succeeds' {
-            { Add-VMImage -publisher "Canonical" -offer "UbuntuServer" -sku "16.04.1-LTS" -version "1.0.4" -osType Linux -EnvironmentName $EnvironmentName -osDiskLocalPath $ubuntuPath -tenantID $AadTenant -AzureStackCredential $stackLoginCreds} | 
+            { Add-AzSVMImage -publisher "Canonical" -offer "UbuntuServer" -sku "16.04.1-LTS" -version "1.0.4" -osType Linux -osDiskLocalPath $ubuntuPath} | 
                 Should Not Throw
         }
 
@@ -100,7 +100,7 @@ InModuleScope $script:ModuleName {
                 $newOffer = "UbuntuServer"
                 $newSKU = "16.04.1-LTS"
                 $newVersion = "1.0.4"
-                Remove-VMImage -publisher $newPub -offer $newOffer -sku $newSKU -version $newVersion -tenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredential $stackLoginCreds
+                Remove-AzSVMImage -publisher $newPub -offer $newOffer -sku $newSKU -version $newVersion
                 $GalleryItemName = "$newOffer$newSKU"
                 $GalleryItemName = $GalleryItemName -replace "\.","-"
                 Get-AzureRMGalleryItem | Where-Object {$_.Name -contains "$newPub.$GalleryItemName.$newVersion"} | Remove-AzureRMGalleryItem

--- a/Infrastructure/AzureStack.Infra.psm1
+++ b/Infrastructure/AzureStack.Infra.psm1
@@ -2,966 +2,634 @@
 # See LICENSE.txt in the project root for license information.
 
 #requires -Version 4.0
-#requires -Modules AzureStack.Connect
-
 
 <#
     .SYNOPSIS
     List Active & Closed Infrastructure Alerts
 #>
-Function Get-AzSAlert{
-    [CmdletBinding(DefaultParameterSetName='GetAlert')]
-    Param(    
-        [Parameter(Mandatory=$true, ParameterSetName='GetAlert')]
-        [ValidateNotNullorEmpty()]
-        [String] $tenantId,
-        
-        [Parameter(ParameterSetName='GetAlert')]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-        
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetAlert')]
-        [string] $EnvironmentName,
-        
-        [Parameter(ParameterSetName='GetAlert')]
-        [string] $region = 'local'
-
+function Get-AzSAlert
+{
+    Param(
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.InfrastructureInsights.Admin/regionHealths/$region/Alerts?api-version=2016-05-01"
-    $Alert=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Alerts=$Alert.value
-    $Alertsprop=$Alerts.properties 
-    $Alertsprop 
+
+    $resourceType = "Microsoft.InfrastructureInsights.Admin/regionHealths/Alerts"
+
+    $alerts = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $alerts.Properties
 }
-export-modulemember -function Get-AzSAlert
+
+Export-ModuleMember -function Get-AzSAlert
 
 <#
     .SYNOPSIS
     List Azure Stack Scale Units in specified Region
 #>
-Function Get-AzSScaleUnit{
-    [CmdletBinding(DefaultParameterSetName='ScaleUnit')]
+function Get-AzSScaleUnit
+{
     Param(
-        [Parameter(Mandatory=$true, ParameterSetName='ScaleUnit')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,  
-        
-        [Parameter(Mandatory=$true, ParameterSetName='ScaleUnit')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-        
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='ScaleUnit')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='ScaleUnit')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)   
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/ScaleUnits?api-version=2016-05-01"
-    $Cluster=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Cluster.value |select name,location,properties
-   
-}       
-export-modulemember -function Get-AzSScaleUnit
+
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/ScaleUnits"
+
+    $cluster = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $cluster
+}
+
+Export-ModuleMember -function Get-AzSScaleUnit
 
 <#
     .SYNOPSIS
     List Nodes in Scale Unit 
 #>
-Function Get-AzSScaleUnitNode{
-    [CmdletBinding(DefaultParameterSetName='GetNode')]
+function Get-AzSScaleUnitNode
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetNode')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetNode')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetNode')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetNode')]
-        [string] $region = 'local'
-
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/scaleunitnodes?api-version=2016-05-01"
-    $nodes=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $nodesprop=$nodes.value
-    $nodesprop|select name,location,properties
+
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/scaleunitnodes"
+    
+    $nodesprop = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $nodesprop
 }
-       
-export-modulemember -function Get-AzSScaleUnitNode
+
+Export-ModuleMember -function Get-AzSScaleUnitNode
 
 <#
     .SYNOPSIS
     List total storage capacity 
 #>
-Function Get-AzSStorageCapacity{
-    [CmdletBinding(DefaultParameterSetName='GetStorageCapacity')]
+function Get-AzSStorageCapacity
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetStorageCapacity')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetStorageCapacity')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetStorageCapacity')]
-
-        [string] $EnvironmentName,
-
-
-        [Parameter(ParameterSetName='GetStorageCapacity')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/storagesubSystems"
 
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/storagesubSystems?api-version=2016-05-01"
-    $Storage=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Storageprop=$storage.value
-    $storageprop|select name,location,properties
-    
+    $storage = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $storage
 }
-export-modulemember -function Get-AzSStorageCapacity
+
+Export-ModuleMember -function Get-AzSStorageCapacity
 
 <#
     .SYNOPSIS
     List Infrastructure Roles 
 #>
-Function Get-AzSInfraRole{
-    [CmdletBinding(DefaultParameterSetName='GetInfraRole')]
+function Get-AzSInfrastructureRole
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetInfraRole')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetInfraRole')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetInfraRole')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetInfraRole')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
 
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/InfraRoles"
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/InfraRoles?api-version=2016-05-01"
-    $Roles=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $roles.value|select name,properties
-    
-}      
-export-modulemember -function Get-AzSInfraRole
+    $roles = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $roles
+}
+
+Export-ModuleMember -function Get-AzSInfrastructureRole
 
 <#
     .SYNOPSIS
     List Infrastructure Role Instances
 #>
 
-Function Get-AzSInfraRoleInstance{
-    [CmdletBinding(DefaultParameterSetName='GetInfraRoleInstance')]
+function Get-AzSInfrastructureRoleInstance
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetInfraRoleInstance')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetInfraRoleInstance')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetInfraRoleInstance')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetInfraRoleInstance')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
 
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/infraRoleInstances?api-version=2016-05-01"
-    $VMs=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $VMprop=$VMs.value
-    $VMprop|select name,properties 
-    
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/infraRoleInstances"
+
+    $VMs = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $VMs
 }       
-export-modulemember -function Get-AzSInfraRoleInstance
+
+Export-ModuleMember -function Get-AzSInfrastructureRoleInstance
 
 <#
     .SYNOPSIS
     List File Shares
 #>
-Function Get-AzSStorageShare{
-    [CmdletBinding(DefaultParameterSetName='GetShare')]
+function Get-AzSStorageShare
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetShare')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetShare')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetShare')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetShare')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/fileShares?api-version=2016-05-01"
-    $Shares=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Shareprop=$Shares.value
-    $Shareprop|select name,location,properties
     
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/fileShares"
+
+    $shares = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $shares
 }
-export-modulemember -function Get-AzSStorageShare
+
+Export-ModuleMember -function Get-AzSStorageShare
 
 <#
     .SYNOPSIS
     List Logical Networks
 #>
-Function Get-AzSLogicalNetwork{
-    [CmdletBinding(DefaultParameterSetName='Getlogicalnetwork')]
+function Get-AzSLogicalNetwork
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='Getlogicalnetwork')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='Getlogicalnetwork')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='Getlogicalnetwork')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='Getlogicalnetwork')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/logicalNetworks?api-version=2016-05-01"
-    $LNetworks=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $LNetworkprop=$LNetworks.value
-    $LNetworkprop|select name,location,properties
     
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/logicalNetworks"
+
+    $LNetworks = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $LNetworks
 }
-export-modulemember -function Get-AzSLogicalNetwork
+
+Export-ModuleMember -function Get-AzSLogicalNetwork
 
 <#
     .SYNOPSIS
     List Region Update Summary
 #>
-Function Get-AzSUpdateSummary{
-    [CmdletBinding(DefaultParameterSetName='GetUpdateSummary')]
+function Get-AzSUpdateSummary
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetUpdateSummary')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetUpdateSummary')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetUpdateSummary')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetUpdateSummary')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Update.Admin/updatelocations/$region/regionUpdateStatus?api-version=2016-05-01"
-    $USummary=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $USummaryprop=$USummary.value
-    $USummaryprop.properties|select locationName,currentversion,lastUpdated,lastChecked,state
     
+    $resourceType = "Microsoft.Update.Admin/updatelocations/regionUpdateStatus"
+
+    $updates = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $updates.Properties
 }
-export-modulemember -function Get-AzSUpdateSummary
+
+Export-ModuleMember -function Get-AzSUpdateSummary
 
 <#
     .SYNOPSIS
     List Available Updates
 #>
-Function Get-AzSUpdate{
-    [CmdletBinding(DefaultParameterSetName='GetUpdate')]
+function Get-AzSUpdate
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetUpdate')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetUpdate')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetUpdate')]
-        [string] $EnvironmentName,
-
-
-        [Parameter(ParameterSetName='GetUpdate')]
-        [string] $region = 'local'
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Update.Admin/updatelocations/$region/updates?api-version=2016-05-01"
-    $Updates=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Updateprop=$Updates.value
-    $Updateprop.properties|select updateName,version,isApplicable,description,state,isDownloaded,packageSizeInMb,kblink
-    
+    $resourceType = "Microsoft.Update.Admin/updatelocations/updates"
+
+    $updates = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $updates | select UpdateName, Version, IsApplicable, Description, State, IsDownloaded, PackageSizeInMb, KbLink    
 }
-export-modulemember -function Get-AzSUpdate
+
+Export-ModuleMember -function Get-AzSUpdate
 
 <#
     .SYNOPSIS
     List Status for a specific Update Run
 #>
-Function Get-AzSUpdateRun{
-    [CmdletBinding(DefaultParameterSetName='GetUpdateRun')]
+function Get-AzSUpdateRun
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetUpdateRun')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
+        [string] $Region = $null,
         
-        [Parameter(Mandatory=$true, ParameterSetName='GetUpdateRun')]
+        [Parameter(Mandatory=$true)]
         [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetUpdateRun')]
-        [string] $EnvironmentName,
-
-
-        [Parameter(ParameterSetName='GetUpdateRun')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true, ParameterSetName='GetUpdateRun')]
-        [ValidateNotNullorEmpty()]
-        [String] $vupdate
+        [String] $Update
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Update.Admin/updatelocations/$region/updates/$vupdate/updateRuns?api-version=2016-05-01"
-    $UpdateRuns=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Updaterunprop=$UpdateRuns.value
-    $Updaterunprop.properties|select updateLocation,updateversion,state,timeStarted,duration
     
+    $region = Get-AzSLocation -Location $Region
+    $name = "{0}/{1}" -f $region, $Update
+    $resourceType = "Microsoft.Update.Admin/updatelocations/updates/updateRuns"
+
+    $updates = Get-AzSInfrastructureResource -name $name -region $region -resourceType $resourceType    
+    $updates | select UpdateLocation, UpdateVersion, State, TimeStarted, Duration
 }
-export-modulemember -function Get-AzSUpdateRun
+
+Export-ModuleMember -function Get-AzSUpdateRun
 
 <#
     .SYNOPSIS
     Apply Azure Stack Update 
 #>
-Function Install-AzSUpdate{
-    [CmdletBinding(DefaultParameterSetName='ApplyUpdate')]
+function Install-AzSUpdate
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='ApplyUpdate')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
+        [string] $Region = $null,
         
-        [Parameter(Mandatory=$true, ParameterSetName='ApplyUpdate')]
+        [Parameter(Mandatory=$true)]
         [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='ApplyUpdate')]
-        [string] $EnvironmentName,
-
-
-        [Parameter(ParameterSetName='ApplyUpdate')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true, ParameterSetName='ApplyUpdate')]
-        [ValidateNotNullorEmpty()]
-        [String] $vupdate
+        [String] $Update
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Update.Admin/updatelocations/$region/updates?api-version=2016-05-01"
-    $Updates=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Updateprop=$Updates.value
-    $Update=$updateprop |where-object {$_.name -eq "$vupdate"}
-    $StartUpdateBody = $update | ConvertTo-Json
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Update.Admin/updatelocations/$region/updates/$vupdate ?api-version=2016-05-01"
-    $Runs=Invoke-RestMethod -Method PUT -Uri $uri -ContentType 'application/json' -Headers $Headers -Body $StartUpdateBody
-    $Startrun=$Runs.value
-    $Startrun   
-    
+    $updates =  Get-AzSUpdate -Region $Region
+        
+    $updateContent = $updates | Where-Object {$_.UpdateName -eq $Update}
+            
+    $params = @{
+        ResourceType = "Microsoft.Update.Admin/updatelocations/updates"
+        ResourceName = "{0}/{1}" -f $Region, $Update
+        ApiVersion = "2016-05-01"
+        Properties = $updateContent
+    }
+
+    $StartRun = New-AzureRmResource @params -Force
+
+    $StartRun
 }
-export-modulemember -function Install-AzSUpdate
+
+Export-ModuleMember -function Install-AzSUpdate
 
 <#
     .SYNOPSIS
     Close Active Alert
 #>
-Function Close-AzSAlert{
-    [CmdletBinding(DefaultParameterSetName='closealert')]
+function Close-AzSAlert
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='closealert')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='closealert')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
+        [string] $Region = $null,
 
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='closealert')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='closealert')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true, ParameterSetName='closealert')]
         [ValidateNotNullorEmpty()]
-        [String] $alertid
+        [String] $AlertId
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.InfrastructureInsights.Admin/regionHealths/$region/Alerts?api-version=2016-05-01"
-    $Alert=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Alerts=$Alert.value |where-object {$_.properties.alertid -eq "$alertid"}
-    $alertname=$alerts.name
-    $Alerts.properties.state = "Closed"
-    $AlertUpdateBody = $Alerts | ConvertTo-Json
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.InfrastructureInsights.Admin/regionHealths/$region/Alerts/${alertname}?api-version=2016-05-01"
-    $Close=Invoke-RestMethod -Method PUT -Uri $uri -ContentType 'application/json' -Headers $Headers -Body $AlertUpdateBody
-    $CloseRun=$Close.value
-    $closeRun 
     
+    $region = Get-AzSLocation -Location $Region
 
+    $alerts = Get-AzSAlert -Region $region
+    
+    $alert = $alerts | Where-Object { $_.AlertId -eq "$AlertId" }
+
+    if($null -ne $alert)
+    {
+        $alertName = $alert.AlertId
+        $alert.state = "Closed"
+        
+        $params = @{
+            ApiVersion = "2016-05-01"
+            ResourceName = "{0}/{1}" -f $region, $alertName
+            ResourceType =  "Microsoft.InfrastructureInsights.Admin/regionHealths/Alerts"
+            ResourceGroupName = "system.{0}" -f $region
+            Properties = $alert
+        }
+
+        Set-AzureRmResource @params -Force
+    }
 }
-export-modulemember -function Close-AzSAlert
+
+Export-ModuleMember -function Close-AzSAlert
 
 <#
     .SYNOPSIS
     List IP Address Pools
 #>
-Function Get-AzSIPPool{
-    [CmdletBinding(DefaultParameterSetName='GetIPPool')]
+function Get-AzSIPPool
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetIPPool')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetIPPool')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetIPPool')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetIPPool')]
-        [string] $region = 'local'
-
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
+    
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/IPPools"
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/IPPools?api-version=2016-05-01"
-    $IPPools=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $IPPoolprop=$IPPools.value
-    $IPPoolprop.properties|select startIpAddress,endIpAddress,numberOfIpAddresses,numberOfAllocatedIpAddresses
+    $IPPool = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $IPPool.Properties
 }
-export-modulemember -function Get-AzSIPPool
 
+Export-ModuleMember -function Get-AzSIPPool
 
 <#
     .SYNOPSIS
     List MAC Address Pools
 #>
-Function Get-AzSMaCPool{
-    [CmdletBinding(DefaultParameterSetName='GetMaCPool')]
+function Get-AzSMaCPool
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetMaCPool')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetMaCPool')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetMaCPool')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetMaCPool')]
-        [string] $region = 'local'
-
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/MacAddressPools?api-version=2016-05-01"
-    $MACPools=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $MaCPoolsprop=$MaCPools.value
-    $MaCPoolsprop.properties|select startmacAddress,endmacAddress,numberOfmacAddresses,numberOfAllocatedmacAddresses
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/MacAddressPools"
+
+    $MACPools = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $MACPools.Properties
 }
-export-modulemember -function Get-AzSMaCPool
+
+Export-ModuleMember -function Get-AzSMaCPool
 
 <#
     .SYNOPSIS
    List Gateway Pools
 #>
-
-Function Get-AzSGatewayPool{
-    [CmdletBinding(DefaultParameterSetName='GetGatewayPool')]
+function Get-AzSGatewayPool
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetGatewayPool')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetGatewayPool')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetGatewayPool')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetGatewayPool')]
-        [string] $region = 'local'
-
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/edgeGatewayPools?api-version=2016-05-01"
-    $GatewayPools=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $MGatewaysprop=$GatewayPools.value
-    $MGatewaysprop.properties|select Gatewaytype,numberofgateways,redundantGatewayCount,gatewayCapacityKiloBitsPerSecond,publicIpAddress
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/edgeGatewayPools"
+
+    $GatewayPools = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $GatewayPools.Properties
 }
-export-modulemember -function Get-AzSGatewayPool
+
+Export-ModuleMember -function Get-AzSGatewayPool
 
 <#
     .SYNOPSIS
     List SLB MUX
 #>
-
-
-Function Get-AzSSLBMUX{
-    [CmdletBinding(DefaultParameterSetName='GetSLBMUX')]
+function Get-AzSSLBMUX
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetSLBMUX')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetSLBMUX')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetSLBMUX')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetSLBMUX')]
-        [string] $region = 'local'
-
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/SlbMuxInstances?api-version=2016-05-01"
-    $SLBMUX=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $SLBMUXprop=$SLBMUX.value
-    $SLBMUXprop.properties|select VirtualServer,ConfigurationState
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/SlbMuxInstances"
+
+    $SLBMUX = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $SLBMUX.Properties
 }
-export-modulemember -function Get-AzSSLBMUX
+
+Export-ModuleMember -function Get-AzSSLBMUX
 
 <#
     .SYNOPSIS
     List Gateways
 #>
-
-Function Get-AzSGateway{
-    [CmdletBinding(DefaultParameterSetName='GetGateway')]
+function Get-AzSGateway
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetGateway')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetGateway')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetGateway')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetGateway')]
-        [string] $region = 'local'
-
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/edgegateways?api-version=2016-05-01"
-    $Gateways=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Gatewaysprop=$Gateways.value
-    $Gatewaysprop.properties|select state, numberofconnections,totalcapacity,availablecapacity
+    $resourceType = "Microsoft.Fabric.Admin/fabricLocations/edgegateways"
+
+    $Gateways = Get-AzSInfrastructureResource -region $Region -resourceType $resourceType
+    $Gateways.Properties
 }
-export-modulemember -function Get-AzSGateway
 
+Export-ModuleMember -function Get-AzSGateway
 
 <#
     .SYNOPSIS
     Start Infra Role Instance
 #>
-
-Function Start-AzSInfraRoleInstance{
-    [CmdletBinding(DefaultParameterSetName='StartInfraRoleInstance')]
+function Start-AzSInfrastructureRoleInstance
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='StartInfraRoleInstance')]
+        [string] $Region = $null,
+
+        [Parameter(Mandatory=$true)]
         [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='StartInfraRoleInstance')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='StartInfraRoleInstance')]
-        [string] $EnvironmentName,
+        [string] $Name,
 
-        [Parameter(ParameterSetName='StartInfraRoleInstance')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true,ParameterSetName='StartInfraRoleInstance')]
-        [string] $Name
-
+        [switch] $Force
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
+    
+    if($Force.IsPresent -or $PSCmdlet.ShouldContinue("Are you sure to start $Name ?",""))
+    {
+        $resourceType = "Microsoft.Fabric.Admin/fabricLocations/infraRoleInstances"
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/infraroleinstances/$name/poweron?api-version=2016-05-01"
-    $PowerON=Invoke-RestMethod -Method Post -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $PowerON
+        Invoke-AzSInfrastructureAction -Name $Name -Action "poweron" -Region $Region -ResourceType $resourceType
+    }
 }
-export-modulemember -function Start-AzSInfraRoleInstance
+
+Export-ModuleMember -function Start-AzSInfrastructureRoleInstance
 
 
 <#
     .SYNOPSIS
     Shutdown Infra Role Instance
 #>
-
-Function Stop-AzSInfraRoleInstance{
-    [CmdletBinding(DefaultParameterSetName='StopInfraRoleInstance')]
+function Stop-AzSInfrastructureRoleInstance
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='StopInfraRoleInstance')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='StopInfraRoleInstance')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='StopInfraRoleInstance')]
-        [string] $EnvironmentName,
+       [string] $Region = $null,
+       
+       [Parameter(Mandatory=$true)]
+       [ValidateNotNullorEmpty()]
+       [string] $Name,
 
-        [Parameter(ParameterSetName='StopInfraRoleInstance')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true,ParameterSetName='StopInfraRoleInstance')]
-        [string] $Name
-
+       [switch] $Force
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/infraroleinstances/$name/shutdown?api-version=2016-05-01"      
-    $PowerOff=Invoke-RestMethod -Method Post -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $PowerOff
+    if($Force.IsPresent -or $PSCmdlet.ShouldContinue("Are you sure to shut down $Name ?",""))
+    {        
+        $resourceType = "Microsoft.Fabric.Admin/fabricLocations/infraRoleInstances"
+
+        Invoke-AzSInfrastructureAction -Name $Name -Action "shutdown" -Region $Region -ResourceType $resourceType
+    }
 }
-export-modulemember -function Stop-AzSInfraRoleInstance
+
+Export-ModuleMember -function Stop-AzSInfrastructureRoleInstance
 
 
 <#
     .SYNOPSIS
     Restart Infra Role Instance
 #>
-
-Function Restart-AzSInfraRoleInstance{
-    [CmdletBinding(DefaultParameterSetName='RestartInfraRoleInstance')]
+function Restart-AzSInfrastructureRoleInstance
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='RestartInfraRoleInstance')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
+        [string] $Region = $null,
         
-        [Parameter(Mandatory=$true, ParameterSetName='RestartInfraRoleInstance')]
+        [Parameter(Mandatory=$true)]
         [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='RestartInfraRoleInstance')]
-        [string] $EnvironmentName,
+        [string] $Name,
 
-        [Parameter(ParameterSetName='RestartInfraRoleInstance')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true, ParameterSetName='RestartInfraRoleInstance')]
-        [string] $Name
-
+        [switch] $Force
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/infraroleinstances/$name/reboot?api-version=2016-05-01"      
-    $Restart=Invoke-RestMethod -Method Post -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Restart
+    if($Force.IsPresent -or $PSCmdlet.ShouldContinue("Are you sure to restart $Name ?",""))
+    {
+        $resourceType = "Microsoft.Fabric.Admin/fabricLocations/infraRoleInstances"
+
+        Invoke-AzSInfrastructureAction -Name $Name -Action "reboot" -Region $Region -ResourceType $resourceType
+    }
 }
-export-modulemember -function Restart-AzSInfraRoleInstance
+
+Export-ModuleMember -function Restart-AzSInfrastructureRoleInstance
 
 
 <#
     .SYNOPSIS
     Add IP Address Pool
 #>
-
-Function Add-AzSIPPool{
-    [CmdletBinding(DefaultParameterSetName='AddIPPool')]
+function Add-AzSIPPool
+{
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='AddIPPool')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='AddIPPool')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-	
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='AddIPPool')]
-        [string] $EnvironmentName,
+        [string] $Region = $null,
 
-        [Parameter(ParameterSetName='AddIPPool')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true,ParameterSetName='AddIPPool')]
+        [Parameter(Mandatory=$true)]
         [string] $Name,
 
-        [Parameter(Mandatory=$true,ParameterSetName='AddIPPool')]
-        [string] $StartIPAddress = '',
+        [Parameter(Mandatory=$true)]
+        [string] $StartIPAddress,
 
-        [Parameter(Mandatory=$true,ParameterSetName='AddIPPool')]
-        [string] $EndIPAddress = '',
+        [Parameter(Mandatory=$true)]
+        [string] $EndIPAddress,
 
-        [Parameter(Mandatory=$true,ParameterSetName='AddIPPool')]
         [string] $AddressPrefix = ''
-
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)      
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/IPPools/'$Name'?api-version=2016-05-01"
-    $IPPoolBody=@{
-    name=$name
-    properties=@{"StartIpAddress"="$StartIPAddress";"EndIpAddress"="$EndIPAddress";"AddressPrefix"="$AddressPrefix"}
-    subscription=$subscription
-    location=$region
-    type='Microsoft.Fabric.Admin/fabricLocations/ipPools'
-    id='subscriptions/$subscription/resourcegroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/ipPools/$name'
-    tags=''
+    $region = Get-AzSLocation -Location $Region
+    
+    $params = @{
+        ResourceName = "{0}/{1}" -f $region, $Name
+        ResourceType = "Microsoft.Fabric.Admin/fabricLocations/IPPools"
+        ResourceGroupName = "system.{0}" -f $region
+        ApiVersion = "2016-05-01"
+        Properties = @{  
+            StartIpAddress = "$StartIPAddress"
+            EndIpAddress = "$EndIPAddress"
+            AddressPrefix = "$AddressPrefix"
+        }
+    }
+
+    New-AzureRmResource @params -Force
 }
 
-$IPPoolBodyJson =$IPPoolBody |ConvertTo-Json
-    $NewIPPool=Invoke-RestMethod -Method Put -Uri $uri -ContentType 'application/json' -Headers $Headers -Body $IPPoolBodyJson
-
-}
-export-modulemember -function Add-AzSIPPool
-
+Export-ModuleMember -function Add-AzSIPPool
 
 <#
     .SYNOPSIS
     Enable Maintenance Mode
 #>
-
-Function Disable-AzSScaleUnitNode{
-    [CmdletBinding(DefaultParameterSetName='DisableAzSScaleUnitNode')]
+function Disable-AzSScaleUnitNode
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='DisableAzSScaleUnitNode')]
+        [string] $Region = $null,
+
+        [Parameter(Mandatory=$true)]
         [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='DisableAzSScaleUnitNode')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
+        [string] $Name,
 
-        [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='DisableAzSScaleUnitNode')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='DisableAzSScaleUnitNode')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true, ParameterSetName='DisableAzSScaleUnitNode')]
-        [string] $Name
-
+        [switch] $Force
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
- 
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/scaleunitnodes/$name/StartMaintenanceMode?api-version=2016-05-01"      
-    $Drain=Invoke-RestMethod -Method Post -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Drain
-   
+
+    if($Force.IsPresent -or $PSCmdlet.ShouldContinue("Are you sure to disable scale unit node $Name ?",""))
+    {
+        $resourceType = "Microsoft.Fabric.Admin/fabricLocations/scaleunitnodes"
+
+        Invoke-AzSInfrastructureAction -Action "StartMaintenanceMode" -Name $Name -Region $Region -ResourceType $resourceType
+    }
 }
-export-modulemember -function Disable-AzSScaleUnitNode
+
+Export-ModuleMember -function Disable-AzSScaleUnitNode
 
 
 <#
     .SYNOPSIS
-    Enable Maintenance Mode
+    Disable Maintenance Mode
 #>
-
-Function Enable-AzSScaleUnitNode{
-    [CmdletBinding(DefaultParameterSetName='EnableAzSScaleUnitNode')]
+function Enable-AzSScaleUnitNode
+{
+    [CmdletBinding(SupportsShouldProcess=$true)]
     Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='EnableAzSScaleUnitNode')]
+        [string] $Region = $null,
+
+        [Parameter(Mandatory=$true)]
         [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='EnableAzSScaleUnitNode')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
+        [string] $Name,
 
-	    [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='EnableAzSScaleUnitNode')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='EnableAzSScaleUnitNode')]
-        [string] $region = 'local',
-
-        [Parameter(Mandatory=$true, ParameterSetName='EnableAzSScaleUnitNode')]
-        [string] $Name
-
+        [switch] $Force
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-   
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.Fabric.Admin/fabricLocations/$region/scaleunitnodes/$name/StopMaintenanceMode?api-version=2016-05-01"      
-    $Resume=Invoke-RestMethod -Method Post -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $Resume
     
+    if($Force.IsPresent -or $PSCmdlet.ShouldContinue("Are you sure to enable scale unit node $Name ?",""))
+    {
+        $resourceType = "Microsoft.Fabric.Admin/fabricLocations/scaleunitnodes"
+
+        Invoke-AzSInfrastructureAction -Action "StopMaintenanceMode" -Name $Name -Region $Region -ResourceType $resourceType
+    }
 }
-export-modulemember -function Enable-AzSScaleUnitNode
+
+Export-ModuleMember -function Enable-AzSScaleUnitNode
 
 
 <#
     .SYNOPSIS
     Get Region Capacity
 #>
-
-Function Get-AzSRegionCapacity{
-    [CmdletBinding(DefaultParameterSetName='GetRegionCapacity')]
-    Param(
-    
-        [Parameter(Mandatory=$true, ParameterSetName='GetRegionCapacity')]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-        
-        [Parameter(Mandatory=$true, ParameterSetName='GetRegionCapacity')]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential] $azureStackCredentials,
-
-	    [Parameter(Mandatory=$true, HelpMessage="The Azure Stack Administrator Environment Name", ParameterSetName='GetRegionCapacity')]
-        [string] $EnvironmentName,
-
-        [Parameter(ParameterSetName='GetRegionCapacity')]
-        [string] $region = 'local'
-
-        
-
+function Get-AzSRegionCapacity
+{
+    Param(        
+        [string] $Region = $null
     )
-    $ARMEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-   
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
-    $URI= "${ArmEndpoint}/subscriptions/${subscription}/resourceGroups/system.$region/providers/Microsoft.InfrastructureInsights.Admin/regionHealths?api-version=2016-05-01"
-    $Capacity=Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $Headers
-    $RCapacity=$Capacity.value
-    $RCapacity| select name,properties
+        
+    $region = Get-AzSLocation -Location $Region
+    $name = "../"
+    $resourceType = "Microsoft.InfrastructureInsights.Admin/locations/regionHealths"
 
-    
+    $Capacity = Get-AzSInfrastructureResource -name $name -region $region -resourceType $resourceType
+    $Capacity.Properties
 }
-export-modulemember -function Get-AzSRegionCapacity
+
+Export-ModuleMember -function Get-AzSRegionCapacity
 
 
-Function Set-AzSLocationInformation {
-    Param(    
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullorEmpty()]
-        [String] $TenantId,
-
-        [Parameter(Mandatory = $true)]
-        [System.Management.Automation.PSCredential] $AzureStackCredentials,
-
-        [Parameter(Mandatory = $true)]
-        [string] $EnvironmentName,
-
-        [Parameter(Mandatory = $true)]
-        [string] $Region = 'local',
-
-        [Parameter(Mandatory = $true)]
-        [string] $Latitude = '47.608013',
-
-        [Parameter(Mandatory = $true)]
-        [string] $Longitude = '-122.335167'
-    )
-    $ArmEndpoint = GetARMEndpoint -EnvironmentName $EnvironmentName -ErrorAction Stop
-    $subscription, $headers = (Get-AzureStackAdminSubTokenHeader -TenantId $TenantId -AzureStackCredentials $AzureStackCredentials -EnvironmentName $EnvironmentName)
-    $uri = "{0}/subscriptions/{1}/providers/Microsoft.Subscriptions.Admin/locations/{2}?api-version=2015-11-01" -f $ArmEndpoint, $subscription, $Region
-
-    $obtainedRegion = Invoke-RestMethod -Method GET -Uri $uri -ContentType 'application/json' -Headers $headers
-    $obtainedRegion.latitude = $Latitude
-    $obtainedRegion.longitude = $Longitude
-
-    Invoke-WebRequest -Uri $uri -Method PUT -Body $(Convertto-Json $obtainedRegion) -ContentType 'application/json' -Headers $headers
-}
-Export-ModuleMember -function Set-AzSLocationInformation
-
-Function GetARMEndpoint{
+function Get-AzSLocation
+{
     param(
-        # Azure Stack environment name
-        [Parameter(Mandatory=$true)]
-        [string] $EnvironmentName
-        
+        [string] $Location
     )
 
-    $armEnv = Get-AzureRmEnvironment -Name $EnvironmentName
-    if($armEnv -ne $null) {
-        $ARMEndpoint = $armEnv.ResourceManagerUrl
-    }
-    else {
-        Write-Error "The Azure Stack environment with the name $EnvironmentName does not exist. Create one with Add-AzureStackAzureRmEnvironment." -ErrorAction Stop
+    if($null -ne $Location -and '' -ne $Location)
+    {
+        return $Location
     }
 
-    $ARMEndpoint
+    $locationResource = Get-AzureRmManagedLocation
+    return $locationResource.Name
+}
+
+function Get-AzSInfrastructureResource
+{
+    param(
+        [string] $name = $null,
+        [string] $region,
+        [string] $apiVersion = "2016-05-01",
+        [string] $resourceType
+    )
+    
+    $region = Get-AzSLocation -Location $region
+
+    # If $name is not given, list all resource by using location as ResourceName
+    if($null -eq $name -or '' -eq $name)
+    {       
+        $name = $region
+    }
+
+    $params = @{
+        ApiVersion = $apiVersion
+        ResourceType = $resourceType
+        ResourceName = $name
+        ResourceGroupName = "system.{0}" -f $region
+    }
+
+    $infraResource = Get-AzureRmResource @params
+    return $infraResource
+}
+
+function Invoke-AzSInfrastructureAction
+{
+    param(
+        [string] $Name,
+        [string] $Region,
+        [string] $Action,
+        [string] $ResourceType
+    )
+        
+    $region = Get-AzSLocation -Location $Region
+
+    $params = @{
+        ApiVersion = "2016-05-01"
+        Action = $Action
+        ResourceType = $ResourceType
+        ResourceGroupName = "system.{0}" -f $region
+        ResourceName = "{0}/{1}" -f $region, $Name
+    }
+
+    Invoke-AzureRmResourceAction @params -Force
 }

--- a/Infrastructure/README.md
+++ b/Infrastructure/README.md
@@ -54,30 +54,22 @@ Explains each individual command and shows how to use it
 List active and closed Infrastructure Alerts
 
 ```powershell
-$credential = Get-Credential
-Get-AzSAlert -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSAlert
 ```
 
-Note: The cmdlet requires credentials to retrieve Alerts. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves Active & Closed Alerts
 
 
 ### Close Infrastructure Alerts
 
- Close any active Infrastructure Alert. Run Get-AzureStackAlert to get the AlertID, required to close a specific Alert.
+ Close any active Infrastructure Alert. Run Get-AzSAlert to get the AlertID, required to close a specific Alert.
 
 ```powershell
-$credential = Get-Credential
-Close-AzSAlert -AzureStackCredentials $credential -TenantID $TenantID -AlertID "ID" -EnvironmentName "AzureStackAdmin"
+Close-AzSAlert -AlertID "ID"
 ```
 
-Note: The cmdlet requires credentials to close active Alert. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Close active Alert
 
 
@@ -86,14 +78,10 @@ The command does the following:
  Review the Update Summary for a specified region.
 
 ```powershell
-$credential = Get-Credential
-Get-AzSUpdateSummary -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSUpdateSummary
 ```
 
-Note: The cmdlet requires credentials to retrieve Region Update Summary. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves Region Update Summary
 
 
@@ -102,14 +90,10 @@ The command does the following:
  Retrieves list of Azure Stack Updates
 
 ```powershell
-$credential = Get-Credential
-Get-AzSUpdate -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSUpdate
 ```
 
-Note: The cmdlet requires credentials to retrieve Azure Stack Updates. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - List Azure Stack Updates
 
 
@@ -118,14 +102,10 @@ The command does the following:
  Applies a specific Azure Stack Update that is downloaded and applicable. Run Get-AzureStackUpdate to retrieve Update Version first
 
 ```powershell
-$credential = Get-Credential
-Install-AzSUpdate -AzureStackCredentials $credential -TenantID $TenantID -vupdate "Update Version" -EnvironmentName "AzureStackAdmin"
+Install-AzSUpdate -Update "Update Version"
 ```
 
-Note: The cmdlet requires credentials to apply a specific Update. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Applies specified Update
 
 
@@ -134,14 +114,10 @@ The command does the following:
  Should be used to validate a specific Update Run or look at previous update runs
 
 ```powershell
-$credential = Get-Credential
-Get-AzSUpdateRun -AzureStackCredentials $credential -TenantID $TenantID -vupdate "Update Version" -EnvironmentName "AzureStackAdmin"
+Get-AzSUpdateRun -Update "Update Version"
 ```
 
-Note: The cmdlet requires credentials to retrieve Update Run information. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Lists Update Run information for a specific Azure Stack update
 
 
@@ -150,14 +126,10 @@ The command does the following:
  Does list all Infrastructure Roles
 
 ```powershell
-$credential = Get-Credential
-Get-AzSInfraRole -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSInfraRole
 ```
 
-Note: The cmdlet requires credentials to retrieve Infrastructure Roles. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Lists Infrastructure Roles
 
 
@@ -166,14 +138,10 @@ The command does the following:
  Does list all Infrastructure Role Instances (Note: Does not return Directory Management VM in One Node deployment)
 
 ```powershell
-$credential = Get-Credential
-Get-AzSInfraRoleInstance -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSInfraRoleInstance
 ```
 
-Note: The cmdlet requires credentials to retrieve Infrastructure Role Instances. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Lists Infrastructure Role Instances
 
 
@@ -182,14 +150,10 @@ The command does the following:
  Does list all Scale Units in a specified Region
 
 ```powershell
-$credential = Get-Credential
-Get-AzSScaleUnit -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSScaleUnit
 ```
 
-Note: The cmdlet requires credentials to retrieve Scale Units. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Lists Scale Units
 
 
@@ -198,14 +162,10 @@ The command does the following:
  Does list all Scale Units Nodes
 
 ```powershell
-$credential = Get-Credential
-Get-AzSScaleUnitNode -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSScaleUnitNode
 ```
 
-Note: The cmdlet requires credentials to retrieve all Scale Unit Nodes. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Lists Scale Unit Nodes
 
 
@@ -214,14 +174,10 @@ The command does the following:
  Does list all logical Networks by ID
 
 ```powershell
-$credential = Get-Credential
-Get-AzSLogicalNetwork -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSLogicalNetwork
 ```
 
-Note: The cmdlet requires credentials to retrieve logical Networks. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Lists logical Networks
 
 
@@ -230,14 +186,10 @@ The command does the following:
  Does return the total capacity of the storage subsystem
 
 ```powershell
-$credential = Get-Credential
-Get-AzSStorageCapacity -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSStorageCapacity
 ```
 
-Note: The cmdlet requires credentials to retrieve total storage capacity. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Lists total storage capacity for the storage subsystem
 
 
@@ -246,14 +198,10 @@ The command does the following:
  Does list all file shares in the storage subsystem
 
 ```powershell
-$credential = Get-Credential
-Get-AzSStorageShare -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSStorageShare
 ```
 
-Note: The cmdlet requires credentials to retrieve file shares. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves all file shares
 
 
@@ -262,14 +210,10 @@ The command does the following:
  Does list all IP Pools
 
 ```powershell
-$credential = Get-Credential
-Get-AzSIPPool -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSIPPool
 ```
 
-Note: The cmdlet requires credentials to retrieve IP Pools. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves all IP Pools
 
 
@@ -278,14 +222,10 @@ The command does the following:
  Does list all MAC Address Pool
 
 ```powershell
-$credential = Get-Credential
-Get-AzSMacPool -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSMacPool
 ```
 
-Note: The cmdlet requires credentials to retrieve all MAC Address Pools. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves all MAC Address Pools
 
 
@@ -294,14 +234,10 @@ The command does the following:
  Does list all Gateway Pools
 
 ```powershell
-$credential = Get-Credential
-Get-AzSGatewayPool -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSGatewayPool
 ```
 
-Note: The cmdlet requires credentials to retrieve the Gateway Pools. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves all Gateway Pools
 
 
@@ -310,14 +246,10 @@ The command does the following:
  Does list all SLB MUX Instances
 
 ```powershell
-$credential = Get-Credential
-Get-AzSSLBMUX -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSSLBMUX
 ```
 
-Note: The cmdlet requires credentials to retrieve all SLB MUX instances. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves all SLB MUX instances
 
 
@@ -326,14 +258,10 @@ The command does the following:
  Does list all Gateway Instances
 
 ```powershell
-$credential = Get-Credential
-Get-AzSGateway -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSGateway
 ```
 
-Note: The cmdlet requires credentials to retrieve all Gateway instances. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves all Gateway instances
 
 
@@ -342,14 +270,10 @@ The command does the following:
  Does start an Infra Role Instance
 
 ```powershell
-$credential = Get-Credential
-Start-AzSInfraRoleInstance -AzureStackCredentials $credential -TenantID $TenantID -Name "InfraRoleInstanceName" -EnvironmentName "AzureStackAdmin"
+Start-AzSInfraRoleInstance -Name "InfraRoleInstanceName"
 ```
 
-Note: The cmdlet requires credentials to start an infra role instance. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Starts an Infra Role instance
 
 
@@ -358,14 +282,10 @@ The command does the following:
  Does stop an Infra Role Instance
 
 ```powershell
-$credential = Get-Credential
-Stop-AzSInfraRoleInstance -AzureStackCredentials $credential -TenantID $TenantID -Name "InfraRoleInstanceName" -EnvironmentName "AzureStackAdmin"
+Stop-AzSInfraRoleInstance -Name "InfraRoleInstanceName"
 ```
 
-Note: The cmdlet requires credentials to stop an infra role instance. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Stops an Infra Role instance
 
 
@@ -374,14 +294,10 @@ The command does the following:
  Does restart an Infra Role Instance
 
 ```powershell
-$credential = Get-Credential
-Restart-AzSInfraRoleInstance -AzureStackCredentials $credential -TenantID $TenantID -Name "InfraRoleInstanceName" -EnvironmentName "AzureStackAdmin"
+Restart-AzSInfraRoleInstance -Name "InfraRoleInstanceName"
 ```
 
-Note: The cmdlet requires credentials to restart an infra role instance. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Restart an Infra Role instance
 
 
@@ -390,14 +306,10 @@ The command does the following:
  Does add an IP Pool
 
 ```powershell
-$credential = Get-Credential
-Add-AzSIPPool -AzureStackCredentials $credential -TenantID $TenantID -Name "PoolName" -StartIPAddress "192.168.55.1" -EndIPAddress "192.168.55.254" -AddressPrefix "192.168.0./24" -EnvironmentName "AzureStackAdmin"
+Add-AzSIPPool -Name "PoolName" -StartIPAddress "192.168.55.1" -EndIPAddress "192.168.55.254" -AddressPrefix "192.168.0./24"
 ```
 
-Note: The cmdlet requires credentials to add an IP Pool. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Adds an IP Pool
 
 
@@ -406,14 +318,10 @@ The command does the following:
  Does put a ScaleUnitNode in Maintenance Mode
 
 ```powershell
-$credential = Get-Credential
-Disable-AzSScaleUnitNode -TenantId $TenantID -AzureStackCredentials $credential -EnvironmentName "AzureStackAdmin" -Name NodeName
+Disable-AzSScaleUnitNode -Name NodeName
 ```
 
-Note: The cmdlet requires credentials to enable Maintenance Mode. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Enables Maintenance Mode for a specified ScaleUnitNode
 
 
@@ -422,14 +330,10 @@ The command does the following:
  Does resume a ScaleUnitNode from Maintenance Mode
 
 ```powershell
-$credential = Get-Credential
-Enable-AzSScaleUnitNode -TenantId $TenantID -AzureStackCredentials $credential -EnvironmentName "AzureStackAdmin" -Name NodeName
+Enable-AzSScaleUnitNode -Name NodeName
 ```
 
-Note: The cmdlet requires credentials to disable Maintenance Mode. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Resume from Maintenance Mode for a specified ScaleUnitNode
 
 
@@ -438,14 +342,10 @@ The command does the following:
  Does show capacity for specified Region
 
 ```powershell
-$credential = Get-Credential
-Get-AzSRegionCapacity -TenantId $TenantID -AzureStackCredentials $credential -EnvironmentName "AzureStackAdmin"
+Get-AzSRegionCapacity
 ```
 
-Note: The cmdlet requires credentials to display region capacity information. Provide the administrator Azure Active Directory credentials, such as *&lt;Admin Account&gt;*@*&lt;mydirectory&gt;*.onmicrosoft.com or the ADFS credentials, to the prompt.  
-
 The command does the following:
-- Authenticates to the Azure Stack environment
 - Retrieves Region Capacity information
 
 ## Scenario Command Usage
@@ -455,64 +355,64 @@ Demonstrates using multiple commands together for an end to end scenario.
 
 ```powershell
 #Retrieve all Alerts and apply a filter to only show active Alerts
-$Active=Get-AzSAlert -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"|where {$_.state -eq "active"}
+$Active=Get-AzSAlert | Where {$_.State -eq "active"}
 $Active
 
 #Stop Infra Role Instance
-Stop-AzSInfraRoleInstance -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin" -Name $Active.resourceName
+Stop-AzSInfraRoleInstance -Name $Active.ResourceName
 
 #Start Infra Role Instance
-Start-AzSInfraRoleInstance -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin" -Name $Active.resourceName
+Start-AzSInfraRoleInstance -Name $Active.resourceName
 
 #Validate if error is resolved (Can take up to 3min)
-Get-AzSAlert -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"|where {$_.state -eq "active"}
+Get-AzSAlert | Where {$_.State -eq "active"}
 ```
 
 
 ### Increase Public IP Pool Capacity
 ```powershell
 #Retrieve all Alerts and apply a filter to only show active Alerts
-$Active=Get-AzSAlert -AzureStackCredentials $cred -TenantID $TenantID -EnvironmentName "AzureStackAdmin"|where {$_.state -eq "active"}
+$Active=Get-AzSAlert | Where {$_.State -eq "active"}
 $Active
 
 #Review IP Pool Allocation
-Get-AzSIPPool -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSIPPool
 
 #Add New Public IP Pool
-Add-AzSIPPool -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin" -Name "NewPublicIPPool" -StartIPAddress "192.168.80.0" -EndIPAddress "192.168.80.255" -AddressPrefix "192.168.80.0/24"
+Add-AzSIPPool -Name "NewPublicIPPool" -StartIPAddress "192.168.80.0" -EndIPAddress "192.168.80.255" -AddressPrefix "192.168.80.0/24"
 
 #Validate new IP Pool
-Get-AzSIPPool -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSIPPool
 ```
 
 ### Apply Update to Azure Stack
 ```powershell
 #Review Current Region Update Summary
-Get-AzSUpdateSummary -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSUpdateSummary
 
 #Check for available and applicable updates
-Get-AzSUpdate -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSUpdate
 
 #Apply Update
-Install-AzSUpdate -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin" -vupdate "2.0.0.0"
+Install-AzSUpdate -Update "2.0.0.0"
 
 #Check Update Run
-Get-AzSUpdateRun -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin" -vupdate "2.0.0.0"
+Get-AzSUpdateRun -Update "2.0.0.0"
 
 #Review Region Update Summary after successful run
-Get-AzSUpdateSummary -AzureStackCredentials $credential -TenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Get-AzSUpdateSummary
 ```
 
 
 ### Perform FRU procedure
 ```powershell
 #Review current ScaleUnitNode State
-$node=Get-AzSScaleUnitNode -TenantId $TenantID -AzureStackCredentials $credentials-EnvironmentName AzureStackAdmin
-$node.properties | fl
+$node=Get-AzSScaleUnitNode
+$node | fl
 
 
 #Enable Maintenance Mode for that node which drains all active resources
-Disable-AzSScaleUnitNode -TenantId $TenantID -AzureStackCredentials $credential -EnvironmentName "AzureStackAdmin" -Name $node.name
+Disable-AzSScaleUnitNode -Name $node.name
 
 #Power Off Server using build in KVN or physical power button
 #BMC IP Address is returned by previous command $node.properties | fl
@@ -520,27 +420,9 @@ Disable-AzSScaleUnitNode -TenantId $TenantID -AzureStackCredentials $credential 
 #Power On Server using build in KVN or physical power button
 
 #Resume ScaleUnitNode from Maintenance Mode
-Enable-AzSScaleUnitNode -TenantId $TenantID -AzureStackCredentials $credential -EnvironmentName "AzureStackAdmin" -Name $node.name
+Enable-AzSScaleUnitNode -Name $node.name
 
 #Validate ScaleUnitNode Status
-$node=Get-AzSScaleUnitNode -TenantId $TenantID -AzureStackCredentials $credentials-EnvironmentName AzureStackAdmin
-$node.properties | fl
-```
-
-
-### Set Azure Stack's Latitude and Longitude
-
-This command modifies an Azure Stack instance's latitude and longitude location
-
-```powershell
-$EnvironmentName = "AzureStackAdmin"
-$directoryName = "<<yourDirectoryName>>.onmicrosoft.com"
-$credential = Get-Credential
-$latitude = '12.972442'
-$longitude = '77.580643'
-$regionName = 'local'
-
-$TenantID = Get-DirectoryTenantID -AADTenantName $directoryName -EnvironmentName AzureStackAdmin
-Set-AzSLocationInformation -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $credential -Region $regionName -Latitude $latitude -Longitude $longitude
-
+$node=Get-AzSScaleUnitNode
+$node | fl
 ```

--- a/Infrastructure/README.md
+++ b/Infrastructure/README.md
@@ -126,7 +126,7 @@ The command does the following:
  Does list all Infrastructure Roles
 
 ```powershell
-Get-AzSInfraRole
+Get-AzSInfrastructureRole
 ```
 
 The command does the following:
@@ -138,7 +138,7 @@ The command does the following:
  Does list all Infrastructure Role Instances (Note: Does not return Directory Management VM in One Node deployment)
 
 ```powershell
-Get-AzSInfraRoleInstance
+Get-AzSInfrastructureRoleInstance
 ```
 
 The command does the following:
@@ -270,7 +270,7 @@ The command does the following:
  Does start an Infra Role Instance
 
 ```powershell
-Start-AzSInfraRoleInstance -Name "InfraRoleInstanceName"
+Start-AzSInfrastructureRoleInstance -Name "InfraRoleInstanceName"
 ```
 
 The command does the following:
@@ -282,7 +282,7 @@ The command does the following:
  Does stop an Infra Role Instance
 
 ```powershell
-Stop-AzSInfraRoleInstance -Name "InfraRoleInstanceName"
+Stop-AzSInfrastructureRoleInstance -Name "InfraRoleInstanceName"
 ```
 
 The command does the following:
@@ -294,7 +294,7 @@ The command does the following:
  Does restart an Infra Role Instance
 
 ```powershell
-Restart-AzSInfraRoleInstance -Name "InfraRoleInstanceName"
+Restart-AzSInfrastructureRoleInstance -Name "InfraRoleInstanceName"
 ```
 
 The command does the following:
@@ -359,10 +359,10 @@ $Active=Get-AzSAlert | Where {$_.State -eq "active"}
 $Active
 
 #Stop Infra Role Instance
-Stop-AzSInfraRoleInstance -Name $Active.ResourceName
+Stop-AzSInfrastructureRoleInstance -Name $Active.ResourceName
 
 #Start Infra Role Instance
-Start-AzSInfraRoleInstance -Name $Active.resourceName
+Start-AzSInfrastructureRoleInstance -Name $Active.resourceName
 
 #Validate if error is resolved (Can take up to 3min)
 Get-AzSAlert | Where {$_.State -eq "active"}

--- a/Infrastructure/Tests/Infra.Tests.ps1
+++ b/Infrastructure/Tests/Infra.Tests.ps1
@@ -39,51 +39,46 @@ InModuleScope $script:ModuleName {
 
     Describe 'Infra - Functional Tests' {
         It 'Get-AzSAlert should not throw' {
-            { Get-AzSAlert -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSAlert } |
                 Should Not Throw
         }
         It 'Get-AzSScaleUnit should not throw' {
-            { Get-AzSAlert -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSAlert } |
                 Should Not Throw
         }
         It 'Get-AzSScaleUnitNode should not throw' {
-            { Get-AzSScaleUnitNode -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSScaleUnitNode } |
                 Should Not Throw
         }
         It 'Get-AzSStorageCapacity should not throw' {
-            { Get-AzSStorageCapacity -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSStorageCapacity } |
                 Should Not Throw
         }
         It 'Get-AzSInfraRole should not throw' {
-            { Get-AzSInfraRole -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSInfraRole } |
                 Should Not Throw
         }
         It 'Get-AzSInfraRoleInstance should not throw' {
-            { Get-AzSInfraRoleInstance -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSInfraRoleInstance } |
                 Should Not Throw
         }
         It 'Get-AzSStorageShare should not throw' {
-            { Get-AzSStorageShare -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSStorageShare } |
                 Should Not Throw
         }
         It 'Get-AzSlogicalnetwork should not throw' {
-            { Get-AzSlogicalnetwork -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSlogicalnetwork } |
                 Should Not Throw
         }
         
         It 'Get-AzSUpdateSummary should not throw' {
-            { Get-AzSUpdateSummary -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSUpdateSummary } |
                 Should Not Throw
         }
         It 'Get-AzSUpdate should not throw' {
-            { Get-AzSUpdate -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds } |
+            { Get-AzSUpdate } |
                 Should Not Throw
         }
-        It 'Set-AzSLocationInformation should not throw' {
-            { Set-AzSLocationInformation -TenantID $AadTenant -EnvironmentName $EnvironmentName -AzureStackCredentials $stackLoginCreds -Region 'local' -Latitude '12.972442' -Longitude '77.580643'} |
-                Should Not Throw
-        }
-
 
     }
     

--- a/ServiceAdmin/AzureStack.ServiceAdmin.psm1
+++ b/ServiceAdmin/AzureStack.ServiceAdmin.psm1
@@ -2,49 +2,50 @@
 # See LICENSE.txt in the project root for license information.
 
 #requires -Version 4.0
-#requires -Modules AzureStack.Connect
 
 <#
     .SYNOPSIS
     Creates "default" tenant offer with unlimited quotas across Compute, Network, Storage and KeyVault services.
 #>
-function New-AzSTenantOfferAndQuotas
+function Add-AzSTenantOfferAndQuota
 {
     param (
         [parameter(HelpMessage="Name of the offer to be made advailable to tenants")]
         [string] $Name ="default",
-        [parameter(HelpMessage="Azure Stack region in which to define plans and quotas")]
-        [string]$Location = "local",
         [Parameter(HelpMessage="If this parameter is not specified all quotas are assigned. Provide a sub selection of quotas in this parameter if you do not want all quotas assigned.")]
         [ValidateSet('Compute','Network','Storage','KeyVault','Subscriptions',IgnoreCase =$true)]
-        [array]$ServiceQuotas,
-        [parameter(Mandatory=$true,HelpMessage="The name of the AzureStack environment")]
-        [string] $EnvironmentName,
-        [parameter(Mandatory=$true,HelpMessage="Azure Stack service administrator credential")]
-        [pscredential] $azureStackCredentials,
-        [parameter(mandatory=$true, HelpMessage="TenantID of Identity Tenant")]
-	    [string] $tenantID
+        [array] $ServiceQuotas,
+        [parameter(HelpMessage="Azure Stack region in which to define plans and quotas")]
+        [string] $Location = "local"
     )
-
-    $azureStackEnvironment = Get-AzureRmEnvironment -Name $EnvironmentName -ErrorAction SilentlyContinue
-    if($azureStackEnvironment -ne $null) {
-        $ARMEndpoint = $azureStackEnvironment.ResourceManagerUrl
-    }
-    else {
-        Write-Error "The Azure Stack Admin environment with the name $EnvironmentName does not exist. Create one with Add-AzureStackAzureRmEnvironment." -ErrorAction Stop
-    }
-
-    Write-Verbose "Obtaining token from AAD..." -Verbose
-    $subscription, $headers =  (Get-AzureStackAdminSubTokenHeader -TenantId $tenantId -AzureStackCredentials $azureStackCredentials -EnvironmentName $EnvironmentName)
 
     Write-Verbose "Creating quotas..." -Verbose
     $Quotas = @()
-    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Compute')){ $Quotas += New-ComputeQuota -AdminUri $armEndPoint -SubscriptionId $subscription -AzureStackTokenHeader $headers -ArmLocation $Location }
-    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Network')){ $Quotas += New-NetworkQuota -AdminUri $armEndPoint -SubscriptionId $subscription -AzureStackTokenHeader $headers -ArmLocation $Location }
-    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Storage')){ $Quotas += New-StorageQuota -AdminUri $armEndPoint -SubscriptionId $subscription -AzureStackTokenHeader $headers -ArmLocation $Location }
-    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'KeyVault')){ $Quotas += Get-KeyVaultQuota -AdminUri $armEndPoint -SubscriptionId $subscription -AzureStackTokenHeader $headers -ArmLocation $Location }
-    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Subscriptions')){ $Quotas += Get-SubscriptionsQuota -AdminUri $armEndpoint -SubscriptionId $subscription -AzureStackTokenHeader $headers -ArmLocation $Location }
+    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Compute')) {
+        Write-Verbose "Creating compute quota..."
+        $Quotas += Add-AzSComputeQuota -Location $Location 
+    }
 
+    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Network')) {
+        Write-Verbose "Creating network quota..."
+        $Quotas += Add-AzSNetworkQuota -Location $Location 
+    }
+
+    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Storage')) {
+        Write-Verbose "Creating storage quota..."
+        $Quotas += Add-AzSStorageQuota -Location $Location 
+    }
+
+    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'KeyVault')) {
+        Write-Verbose "Get default key vault quota..."
+        $Quotas += Get-AzSKeyVaultQuota -Location $Location 
+    }
+
+    if ((!($ServiceQuotas)) -or ($ServiceQuotas -match 'Subscriptions')) {
+        Write-Verbose "Creating subscription quota..."
+        $Quotas += Get-AzSSubscriptionsQuota -Location $Location 
+    }
+    
     Write-Verbose "Creating resource group for plans and offers..." -Verbose
     if (Get-AzureRmResourceGroup -Name $Name -ErrorAction SilentlyContinue)
     {        
@@ -61,116 +62,62 @@ function New-AzSTenantOfferAndQuotas
     return $offer
 }
 
-Export-ModuleMember New-AzSTenantOfferAndQuotas
+Export-ModuleMember Add-AzSTenantOfferAndQuotas
 
-function Get-SubscriptionsQuota
+function Add-AzSStorageQuota
 {
     param(
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $AdminUri,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $SubscriptionId,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [hashtable] $AzureStackTokenHeader,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $ArmLocation  
-    )    
+        [string] $Name                  = "default",
+        [int] $CapacityInGb             = 1000,
+        [int] $NumberOfStorageAccounts  = 2000,
+        [string] $Location              = $null
+    )
+    
+    $Location = Get-AzSLocation -Location $Location    
 
-    $getSubscriptionsQuota = @{
-        Uri = "{0}/subscriptions/{1}/providers/Microsoft.Subscriptions.Admin/locations/{2}/quotas?api-version=2015-11-01" -f $AdminUri, $SubscriptionId, $ArmLocation
-        Method = "GET"
-        Headers = $AzureStackTokenHeader
-        ContentType = "application/json"
-    }
-    $subscriptionsQuota = Invoke-RestMethod @getSubscriptionsQuota
-    $subscriptionsQuota.value.Id
-}
-
-function New-StorageQuota
-{
-    param(
-        [string] $Name ="default",
-        [int] $CapacityInGb = 1000,
-        [int] $NumberOfStorageAccounts = 2000,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $AdminUri,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $SubscriptionId,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [hashtable] $AzureStackTokenHeader,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $ArmLocation  
-    )    
-
-    $ApiVersion = "2015-12-01-preview"
-
-    $uri = "{0}/subscriptions/{1}/providers/Microsoft.Storage.Admin/locations/{2}/quotas/{3}?api-version={4}" -f $AdminUri, $SubscriptionId, $ArmLocation, $Name, $ApiVersion
-    $RequestBody = @"
-    {
-        "name":"$Name",
-        "location":"$ArmLocation",
-        "properties": { 
-            "capacityInGb": $CapacityInGb, 
-            "numberOfStorageAccounts": $NumberOfStorageAccounts
+    $params = @{
+        ResourceName = "{0}/{1}" -f $Location, $Name
+        ResourceType = "Microsoft.Storage.Admin/locations/quotas"
+        ApiVersion = "2015-12-01-preview"
+        Properties = @{  
+            capacityInGb = $CapacityInGb
+            numberOfStorageAccounts = $NumberOfStorageAccounts
         }
     }
-"@
-    $storageQuota = Invoke-RestMethod -Method Put -Uri $uri -Body $RequestBody -ContentType 'application/json' -Headers $AzureStackTokenHeader
-    $storageQuota.Id
+
+    New-AzSServiceQuota @params
 }
 
-function New-ComputeQuota
+function Add-AzSComputeQuota
 {
     param(
-        [string] $Name ="default",
-        [int] $VmCount = 1000,
-        [int] $MemoryLimitMB = 1048576,
-        [int] $CoresLimit = 1000,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $AdminUri,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $SubscriptionId,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [hashtable] $AzureStackTokenHeader,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $ArmLocation  
-    )  
+        [string] $Name         = "default",
+        [int] $VmCount         = 1000,
+        [int] $MemoryLimitMB   = 1048576,
+        [int] $CoresLimit      = 1000,
+        [string] $Location     = $null
+    )
 
-    $ApiVersion = "2015-12-01-preview"
-
-    $uri = "{0}/subscriptions/{1}/providers/Microsoft.Compute.Admin/locations/{2}/quotas/{3}?api-version={4}" -f $AdminUri, $SubscriptionId, $ArmLocation, $Name, $ApiVersion
-    $RequestBody = @"
-    {
-        "name":"$Name",
-        "type":"Microsoft.Compute.Admin/quotas",
-        "location":"$ArmLocation",
-        "properties":{
-            "virtualMachineCount":$VmCount,
-            "memoryLimitMB":$MemoryLimitMB,
-            "coresLimit":$CoresLimit
+    $Location = Get-AzSLocation -Location $Location    
+    
+    $params = @{
+        ResourceName = "{0}/{1}" -f $Location, $Name
+        ResourceType = "Microsoft.Compute.Admin/locations/quotas"
+        ApiVersion = "2015-12-01-preview"
+        Properties = @{
+            virtualMachineCount = $VmCount
+            memoryLimitMB = $MemoryLimitMB
+            coresLimit = $CoresLimit
         }
     }
-"@
-    $computeQuota = Invoke-RestMethod -Method Put -Uri $uri -Body $RequestBody -ContentType 'application/json' -Headers $AzureStackTokenHeader
-    $computeQuota.Id
+    
+    New-AzSServiceQuota @params
 }
 
-function New-NetworkQuota
+function Add-AzSNetworkQuota
 {
     param(
-        [string] $Name ="default",
+        [string] $Name                        = "default",
         [int] $PublicIpsPerSubscription       = 500,
         [int] $VNetsPerSubscription           = 500,
         [int] $GatewaysPerSubscription        = 10,
@@ -178,63 +125,100 @@ function New-NetworkQuota
         [int] $LoadBalancersPerSubscription   = 500,
         [int] $NicsPerSubscription            = 1000,
         [int] $SecurityGroupsPerSubscription  = 500,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $AdminUri,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $SubscriptionId,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [hashtable] $AzureStackTokenHeader,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $ArmLocation  
+        [string] $Location                    = $null
     ) 
     
-    $ApiVersion = "2015-06-15"
-
-    $uri = "{0}/subscriptions/{1}/providers/Microsoft.Network.Admin/locations/{2}/quotas/{3}?api-version={4}" -f $AdminUri, $SubscriptionId, $ArmLocation, $Name, $ApiVersion
-    $id = "/subscriptions/{0}/providers/Microsoft.Network.Admin/locations/{1}/quotas/{2}" -f  $SubscriptionId, $ArmLocation, $quotaName
-    $RequestBody = @"
-    {
-        "id":"$id",
-        "name":"$Name",
-        "type":"Microsoft.Network.Admin/quotas",
-        "location":"$ArmLocation",
-        "properties":{
-            "maxPublicIpsPerSubscription":$PublicIpsPerSubscription,
-            "maxVnetsPerSubscription":$VNetsPerSubscription,
-            "maxVirtualNetworkGatewaysPerSubscription":$GatewaysPerSubscription,
-            "maxVirtualNetworkGatewayConnectionsPerSubscription":$ConnectionsPerSubscription,
-            "maxLoadBalancersPerSubscription":$LoadBalancersPerSubscription,
-            "maxNicsPerSubscription":$NicsPerSubscription,
-            "maxSecurityGroupsPerSubscription":$SecurityGroupsPerSubscription,
+    $Location = Get-AzSLocation -Location $Location
+    
+    $params = @{
+        ResourceName = "{0}/{1}" -f $Location, $Name
+        ResourceType = "Microsoft.Network.Admin/locations/quotas"
+        ApiVersion = "2015-06-15"
+        Properties = @{
+            maxPublicIpsPerSubscription = $PublicIpsPerSubscription
+            maxVnetsPerSubscription = $VNetsPerSubscription
+            maxVirtualNetworkGatewaysPerSubscription = $GatewaysPerSubscription
+            maxVirtualNetworkGatewayConnectionsPerSubscription = $ConnectionsPerSubscription
+            maxLoadBalancersPerSubscription = $LoadBalancersPerSubscription
+            maxNicsPerSubscription = $NicsPerSubscription
+            maxSecurityGroupsPerSubscription = $SecurityGroupsPerSubscription
         }
     }
-"@
-    $networkQuota = Invoke-RestMethod -Method Put -Uri $uri -Body $RequestBody -ContentType 'application/json' -Headers $AzureStackTokenHeader
-    $networkQuota.Id
+    
+    New-AzSServiceQuota @params
 }
 
-function Get-KeyVaultQuota
+function Get-AzSSubscriptionsQuota
 {
     param(
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $AdminUri,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $SubscriptionId,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [hashtable] $AzureStackTokenHeader,
-        [parameter(Mandatory=$true)]
-        [ValidateNotNullOrEmpty()]    
-        [string] $ArmLocation  
-    ) 
+        [string] $Location = $null
+    )
 
-    $uri = "{0}/subscriptions/{1}/providers/Microsoft.Keyvault.Admin/locations/{2}/quotas?api-version=2014-04-01-preview" -f $AdminUri, $SubscriptionId, $ArmLocation
-    $kvQuota = Invoke-RestMethod -Method Get -Uri $uri -Headers $AzureStackTokenHeader -ContentType 'application/json'
-    $kvQuota.Value.Id
+    $Location = Get-AzSLocation -Location $Location
+
+    $params = @{
+        ResourceName = $Location
+        ResourceType = "Microsoft.Subscriptions.Admin/locations/quotas"
+        ApiVersion = "2015-11-01"
+    }
+
+    Get-AzSServiceQuota @params
+}
+
+function Get-AzSKeyVaultQuota
+{
+    param(  
+        [string] $Location = $null
+    )
+    
+    $Location = Get-AzSLocation -Location $Location
+    
+    $params = @{
+        ResourceName = $Location
+        ResourceType = "Microsoft.Keyvault.Admin/locations/quotas"
+        ApiVersion = "2014-04-01-preview"
+    }
+
+    Get-AzSServiceQuota @params
+}
+
+function Get-AzSLocation
+{
+    param(
+        [string] $Location
+    )
+
+    if($null -ne $Location -and '' -ne $Location)
+    {
+        return $Location
+    }
+
+    $locationResource = Get-AzureRmManagedLocation
+    return $locationResource.Name
+}
+
+
+function New-AzSServiceQuota
+{
+    param(
+        [string] $ResourceName,
+        [string] $ResourceType,
+        [string] $ApiVersion,
+        [PSObject] $Properties
+    )
+        
+    $serviceQuota = New-AzureRmResource -ResourceName $ResourceName -ResourceType $ResourceType -ApiVersion $ApiVersion -Properties $Properties -Force
+    $serviceQuota.ResourceId
+}
+
+function Get-AzSServiceQuota
+{
+    param(
+        [string] $ResourceName,
+        [string] $ResourceType,
+        [string] $ApiVersion
+    )
+    
+    $serviceQuota = Get-AzureRmResource -ResourceName $ResourceName  -ApiVersion $ApiVersion -ResourceType $ResourceType
+    $serviceQuota.ResourceId
 }

--- a/ServiceAdmin/README.md
+++ b/ServiceAdmin/README.md
@@ -21,22 +21,10 @@ You will need to reference your Azure Stack Administrator environment. To create
 Add-AzureStackAzureRmEnvironment -Name "AzureStackAdmin" -ArmEndpoint "https://adminmanagement.local.azurestack.external" 
 ```
 
-Creating quotas/offers/plans requires that you obtain the value of your Directory Tenant ID. For **Azure Active Directory** environments provide your directory tenant name:
-
-```powershell
-$TenantID = Get-DirectoryTenantID -AADTenantName "<mydirectorytenant>.onmicrosoft.com" -EnvironmentName AzureStackAdmin 
-```
-
-For **ADFS** environments use the following:
-
-```powershell
-$TenantID = Get-DirectoryTenantID -ADFS -EnvironmentName AzureStackAdmin 
-```
-
 ## Create default plan and quota for tenants
 
 ```powershell
-New-AzSTenantOfferAndQuotas -tenantID $TenantID -EnvironmentName "AzureStackAdmin"
+Add-AzSTenantOfferAndQuota
 ```
 
 Tenants can now see the "default" offer available to them and can subscribe to it. The offer includes unlimited compute, network, storage and key vault usage. 

--- a/ServiceAdmin/Tests/ServiceAdmin.Tests.ps1
+++ b/ServiceAdmin/Tests/ServiceAdmin.Tests.ps1
@@ -11,8 +11,8 @@ Describe $script:ModuleName {
                 Should Not Be $null
         }
 
-        It 'New-AzSTenantOfferAndQuotas should be exported' {
-            Get-Command -Name New-AzSTenantOfferAndQuotas -ErrorAction SilentlyContinue | 
+        It 'Add-AzSTenantOfferAndQuota should be exported' {
+            Get-Command -Name Add-AzSTenantOfferAndQuotas -ErrorAction SilentlyContinue | 
                 Should Not Be $null
         }
 
@@ -21,25 +21,9 @@ Describe $script:ModuleName {
 
 InModuleScope $script:ModuleName {
 
-    $HostComputer = $global:HostComputer
-    $ArmEndpoint = $global:ArmEndpoint
-    $natServer = $global:natServer 
-    $AdminUser= $global:AdminUser 
-    $AadServiceAdmin = $global:AadServiceAdmin 
-
-    $AdminPassword = $global:AdminPassword
-    $AadServiceAdminPassword = $global:AadServiceAdminPassword
-    $stackLoginCreds = $global:AzureStackLoginCredentials
-
-    $VPNConnectionName = $global:VPNConnectionName
-
-    $AadTenant = $global:AadTenantID
-
-    $EnvironmentName = $global:EnvironmentName
-
     Describe 'ServiceAdmin - Functional Tests' {
-        It 'New-AzSTenantOfferAndQuotas should create Quotas, Plan and Offer' {
-            { New-AzSTenantOfferAndQuotas -tenantID $AadTenant -AzureStackCredentials $stackLoginCreds -EnvironmentName $EnvironmentName } |
+        It 'Add-AzSTenantOfferAndQuota should create Quotas, Plan and Offer' {
+            { Add-AzSTenantOfferAndQuotas } |
                 Should Not Throw
         }
 

--- a/Usage/Usagesummary.ps1
+++ b/Usage/Usagesummary.ps1
@@ -4,9 +4,10 @@
     .DESCRIPTION
     Long description
     .EXAMPLE
-    Export-AzureStackUsageDetails -StartTime 2/15/2017 -EndTime 2/16/2017 -AzureStackDomain azurestack.local -AADDomain mydir.onmicrosoft.com -Granularity Hourly
+    Export-AzSUsage -StartTime 2/15/2017 -EndTime 2/16/2017 -Granularity Hourly
 #>
-function Export-AzureStackUsage {
+function Export-AzSUsage 
+{
     Param
     (
         [Parameter(Mandatory = $true)]
@@ -15,12 +16,6 @@ function Export-AzureStackUsage {
         [Parameter(Mandatory = $true)]
         [datetime]
         $EndTime ,
-        [Parameter(Mandatory = $true)]
-        [String]
-        $AzureStackDomain ,
-        [Parameter(Mandatory = $true)]
-        [String]
-        $AADDomain ,
         [Parameter(Mandatory = $false)]
         [ValidateSet("Hourly", "Daily")]
         [String]
@@ -29,14 +24,8 @@ function Export-AzureStackUsage {
         [String]
         $CsvFile = "UsageSummary.csv",
         [Parameter (Mandatory = $false)]
-        [PSCredential]
-        $Credential,
-        [Parameter(Mandatory = $false)]
         [Switch]
         $TenantUsage,
-        [Parameter(Mandatory = $false)]
-        [String]
-        $Subscription,
         [Parameter(Mandatory = $false)]
         [Switch]
         $Force
@@ -66,115 +55,81 @@ function Export-AzureStackUsage {
     }
 
     #Output Files
-    if (Test-Path -Path $CsvFile -ErrorAction SilentlyContinue) {
-        if ($Force) {
+    if (Test-Path -Path $CsvFile -ErrorAction SilentlyContinue)
+    {
+        if ($Force)
+        {
             Remove-Item -Path $CsvFile -Force
         }
-        else {
+        else
+        {
             Write-Host "$CsvFile alreday exists use -Force to overwrite"
             return
         }
     }
     New-Item -Path $CsvFile -ItemType File | Out-Null
 
-    #get auth metadata and acquire token for REST call
-    $api = 'adminmanagement'
-    if ($TenantUsage) {
-        $api = 'management'
-    } 
-    $uri = 'https://{0}.{1}/metadata/endpoints?api-version=1.0' -f $api, $AzureStackDomain
-    $endpoints = (Invoke-RestMethod -Uri $uri -Method Get)
-    $activeDirectoryServiceEndpointResourceId = $endpoints.authentication.audiences[0]
-    $loginEndpoint = $endpoints.authentication.loginEndpoint
-    $authority = $loginEndpoint + $AADDomain + '/'
-    $powershellClientId = '0a7bdc5c-7b57-40be-9939-d4c5fc7cd417'
-
-    #region Auth
-    if ($Credential) {
-        $adminToken = Get-AzureStackToken `
-            -Authority $authority `
-            -Resource $activeDirectoryServiceEndpointResourceId `
-            -AadTenantId $AADDomain `
-            -ClientId $powershellClientId `
-            -Credential $Credential
-    }
-    else {
-        $adminToken = Get-AzureStackToken `
-            -Authority $authority `
-            -Resource $activeDirectoryServiceEndpointResourceId `
-            -AadTenantId $AADDomain `
-            -ClientId $powershellClientId 
-    }
-  
-    if (!$adminToken) {
-        Return
-    }
-    #endregion
-
-    #Setup REST call variables
-    $headers = @{ Authorization = (('Bearer {0}' -f $adminToken)) }
-    $armEndpoint = 'https://{0}.{1}' -f $api, $AzureStackDomain
-
-    if (!$Subscription) {
-        #Get default subscription ID
-        $uri = $armEndpoint + '/subscriptions?api-version=2015-01-01'
-        $result = Invoke-RestMethod -Method GET -Uri $uri  -Headers $headers
-        $Subscription = $result.value[0].subscriptionId
-    }
-
+    $usageResourceType = "Microsoft.Commerce/locations/subscriberUsageAggregates"
+        
     #build usage uri
-    if (!$TenantUsage) {
-        $uri = $armEndpoint + '/subscriptions/{0}/providers/Microsoft.Commerce/subscriberUsageAggregates?api-version=2015-06-01-preview&reportedstartTime={1:s}Z&reportedEndTime={2:s}Z&showDetails=true&aggregationGranularity={3}' -f $Subscription, $StartTime, $EndTime, $Granularity
+    if ($TenantUsage)
+    {
+        $usageResourceType = "Microsoft.Commerce/locations/UsageAggregates"
     }
-    else {
-        $uri = $armEndpoint + '/subscriptions/{0}/providers/Microsoft.Commerce/UsageAggregates?api-version=2015-06-01-preview&reportedstartTime={1:s}Z&reportedEndTime={2:s}Z&showDetails=true&aggregationGranularity={3}' -f $Subscription, $StartTime, $EndTime, $Granularity
-    }
-  
-    Do {
-        $result = Invoke-RestMethod -Method GET -Uri $uri  -Headers $headers -ErrorVariable RestError -Verbose
-        if ($RestError) {
-            return
-        }
-        $usageSummary = @()
-        $uri = $result.NextLink
-        $count = $result.value.Count
-        $Total += $count
-        $result.value  | ForEach-Object {
-            $record = New-Object -TypeName System.Object
-            $resourceInfo = ($_.Properties.InstanceData |ConvertFrom-Json).'Microsoft.Resources'
-            $resourceText = $resourceInfo.resourceUri.Replace('\', '/')
-            $subscription = $resourceText.Split('/')[2]
-            $resourceType = $resourceText.Split('/')[7]
-            $resourceName = $resourceText.Split('/')[8]
-            #$record | Add-Member -Name Name -MemberType NoteProperty -Value $_.Name
-            #$record | Add-Member -Name Type -MemberType NoteProperty -Value $_.Type
-            $record | Add-Member -Name MeterId -MemberType NoteProperty -Value $_.Properties.MeterId
-            if ($meters.ContainsKey($_.Properties.MeterId)) {
-                $record | Add-Member -Name MeterName -MemberType NoteProperty -Value $meters[$_.Properties.MeterId]
-            }
-            $record | Add-Member -Name Quantity -MemberType NoteProperty -Value $_.Properties.Quantity
-            $record | Add-Member -Name UsageStartTime -MemberType NoteProperty -Value $_.Properties.UsageStartTime
-            $record | Add-Member -Name UsageEndTime -MemberType NoteProperty -Value $_.Properties.UsageEndTime
-            $record | Add-Member -Name additionalInfo -MemberType NoteProperty -Value $resourceInfo.additionalInfo
-            $record | Add-Member -Name location -MemberType NoteProperty -Value $resourceInfo.location
-            $record | Add-Member -Name tags -MemberType NoteProperty -Value $resourceInfo.tags
-            $record | Add-Member -Name subscription -MemberType NoteProperty -Value $subscription
-            $record | Add-Member -Name resourceType -MemberType NoteProperty -Value $resourceType
-            $record | Add-Member -Name resourceName -MemberType NoteProperty -Value $resourceName
-            $record | Add-Member -Name resourceUri -MemberType NoteProperty -Value $resourceText
-            $usageSummary += $record
-        }
-        $usageSummary | Export-Csv -Path $CsvFile -Append -NoTypeInformation 
-        if ($PSBoundParameters.ContainsKey(‘Debug’)) {
-            $result.value | Export-Csv -Path "$CsvFile.raw" -Append -NoTypeInformation
-        }
 
+    $params = @{
+        ResourceName = '../' 
+        ResourceType = $usageResourceType
+        ApiVersion = "2015-06-01-preview"
+        ODataQuery = "reportedStartTime={0:s}&reportedEndTime={1:s}&showDetails=true&aggregationGranularity={2}" -f $StartTime, $EndTime, $Granularity
     }
-    While ($count -ne 0)
+
+    $result = Get-AzureRmResource @params -ErrorVariable RestError -Verbose
+
+    if ($RestError)
+    {
+        return
+    }
+
+    $usageSummary = @()
+    $uri = $result.NextLink
+    $count = $result.Count
+    $Total += $count
+    $result  | ForEach-Object 
+    {
+        $record = New-Object -TypeName System.Object
+        $resourceInfo = ($_.Properties.InstanceData | ConvertFrom-Json).'Microsoft.Resources'
+        $resourceText = $resourceInfo.resourceUri.Replace('\', '/')
+        $subscription = $resourceText.Split('/')[2]
+        $resourceType = $resourceText.Split('/')[7]
+        $resourceName = $resourceText.Split('/')[8]
+        #$record | Add-Member -Name Name -MemberType NoteProperty -Value $_.Name
+        #$record | Add-Member -Name Type -MemberType NoteProperty -Value $_.Type
+        $record | Add-Member -Name MeterId -MemberType NoteProperty -Value $_.Properties.MeterId
+        if ($meters.ContainsKey($_.Properties.MeterId)) {
+            $record | Add-Member -Name MeterName -MemberType NoteProperty -Value $meters[$_.Properties.MeterId]
+        }
+        $record | Add-Member -Name Quantity -MemberType NoteProperty -Value $_.Properties.Quantity
+        $record | Add-Member -Name UsageStartTime -MemberType NoteProperty -Value $_.Properties.UsageStartTime
+        $record | Add-Member -Name UsageEndTime -MemberType NoteProperty -Value $_.Properties.UsageEndTime
+        $record | Add-Member -Name additionalInfo -MemberType NoteProperty -Value $resourceInfo.additionalInfo
+        $record | Add-Member -Name location -MemberType NoteProperty -Value $resourceInfo.location
+        $record | Add-Member -Name tags -MemberType NoteProperty -Value $resourceInfo.tags
+        $record | Add-Member -Name subscription -MemberType NoteProperty -Value $subscription
+        $record | Add-Member -Name resourceType -MemberType NoteProperty -Value $resourceType
+        $record | Add-Member -Name resourceName -MemberType NoteProperty -Value $resourceName
+        $record | Add-Member -Name resourceUri -MemberType NoteProperty -Value $resourceText
+        $usageSummary += $record
+    }
+    $usageSummary | Export-Csv -Path $CsvFile -Append -NoTypeInformation 
+    if ($PSBoundParameters.ContainsKey('Debug'))
+    {
+        $result | Export-Csv -Path "$CsvFile.raw" -Append -NoTypeInformation
+    }
+    
     Write-Host "Complete - $Total Usage records written to $CsvFile"
 }
 
 #Main
 
-$aadCred = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList '<user@domain>', (ConvertTo-SecureString -String 'XXX' -AsPlainText -Force)
-Export-AzureStackUsage -StartTime 3/1/2017 -EndTime 3/13/2017 -AzureStackDomain 'local.azurestack.external' -AADDomain '<domain>'  -Credential $aadCred -Granularity Hourly -Debug -Force
+Export-AzSUsage -StartTime 6/10/2017 -EndTime 6/11/2017 -Granularity Hourly -Force


### PR DESCRIPTION
Refactor cmdlets of compute admin, service admin, infrastructure and
usage to use azure environment context, so running cmdlets doesn't need
to pass credential info as parameter everytime.