### PR TITLE
updates registration script with RBAC role creation

### DIFF
--- a/Registration/RegisterWithAzure.ps1
+++ b/Registration/RegisterWithAzure.ps1
@@ -5,224 +5,308 @@
 
 .SYNOPSIS
 
-This script can be used to register Azure Stack POC with Azure. To run this script, you must have a public Azure subscription of any type.
-There must also be an account that is an owner or contributor of the subscription, and you must have registered the AzureStack resource provider
+This script can be used to register Azure Stack with Azure. To run this script, you must have a public Azure subscription of any type.
+You must also have access to an account that is an owner or contributor to that subscription.
 
 .DESCRIPTION
 
 RegisterWithAzure runs scripts already present in Azure Stack (path: $root\CloudDeployment\Setup\Activation\Bridge)to connect your Azure Stack to Azure.
-After connecting with Azure, you can test marketplace syndication by downloading products from the marketplace. Usage data will also default to being reported to Azure for billing purposes.
+After connecting with Azure, you can download products from the marketplace (See the documentation for more information: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-download-azure-marketplace-item).
+Running this script with default parameters will enable marketplace syndication and usage data will default to being reported to Azure.
 To turn these features off see examples below.
 
-The script will follow four steps:
-Configure bridge identity: Creates Azure AD application that is used by Azure Bridge for marketplace syndication and by Usage Bridge to send Usage records (if configured).
-Get registration request: get Azure Stack environment information to create a registration for this Azure Stack in azure
-Register with Azure: uses Azure powershell to create an "Azure Stack Registration" resource on your Azure subscription
-Activate Azure Stack: final step in connecting Azure Stack to be able to call out to Azure
+This script will create several resources by default:
+- A registration resource group and resource in Azure Stack
+- A resource group in Azure
+- A registration resource in the created resource group in Azure
 
-.PARAMETER azureCredential
+See documentation for more detail: https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-register
 
-Powershell object that contains credential information such as user name and password. If not supplied script will request login via gui
+.PARAMETER CloudAdminCredential
 
-.PARAMETER azureAccountId
+Powershell object that contains credential information such as user name and password.The CloudADmin has access to the JEA Computer (also known as Emergency Console).
+If not supplied script will request manual input of username and password
 
-Username for an owner/contributor of the azure subscription. This user must not be an MSA or 2FA account. This parameter is mandatory.
+.PARAMETER AzureSubscriptionId
 
-.PARAMETER azureSubscriptionId
+The subscription Id that will be used for marketplace syndication and usage. The Azure Account Id used during registration must have access to this subscription.
 
-Azure subscription ID that you want to register your Azure Stack with. This parameter is mandatory.
+.PARAMETER JeaComputerName
 
-.PARAMETER azureDirectoryTenantName
+Just-Enough-Access Computer Name, also known as Emergency Console VM.
 
-Name of your AAD Tenant which your Azure subscription is a part of. This parameter is mandatory.
+.PARAMETER ResourceGroupName
 
-.PARAMETER azureEnvironment
+This will be the name of the resource group in Azure where the registration resource is stored. Defaults to "azurestack"
 
-Environment name for use in retrieving tenant details and running several of the activation scripts. Defaults to "AzureCloud".
+.PARAMETER  ResourceGroupLocation
 
-.PARAMETER azureResourceManagerEndpoint
+The location where the resource group will be created. Defaults to "westcentralus"
 
-URI used for ActivateBridge.ps1 that refers to the endpoint for Azure Resource Manager. Defaults to "https://management.azure.com"
+.PARAMETER RegistrationName
 
-.PARAMETER enableSyndication
+The name of the registration resource that will be created in Azure. If none is supplied, defaults to "AzureStack-<CloudId>" where <CloudId> is the CloudId associated with the azure Stack environment
 
-Boolean value used in Register-AzureStack.ps1 to enable marketplace syndication. Defaults to $true
+.PARAMETER AzureEnvironmentName
 
-.PARAMETER reportUsage
+The name of the Azure Environment where resources will be created. Defaults to "AzureCloud"
 
-Boolean value used in Register-AzureStack.ps1 to enable reporting of usage records to Azure. Defaults to $true
+.PARAMETER BillingModel
+
+The billing model that the subscription uses. Select from "Capacity","PayAsYouUse", and "Development". Defaults to "Development"
+
+.PARAMETER MarketplaceSyndicationEnabled
+
+This is a switch that determines if this registration will allow you to download products from the Azure Marketplace. Defaults to $true
+
+.PARAMETER UsageReportingEnabled
+
+This is a switch that determines if usage records are reported to Azure. Defaults to $true
+
+.PARAMETER AgreementNumber
+
+Used when the billing model is set to capacity. If this is the case you will need to provide a specific agreement number associated with your billing agreement.
 
 .EXAMPLE
 
 This example registers your AzureStack account with Azure, enables syndication, and enables usage reporting to Azure.
 This script must be run from the Host machine of the POC.
 
-.\RegisterWithAzure.ps1 -azureCredential $yourCredentials -azureSubscriptionId $subsciptionId -azureDirectoryTenantName "contoso.onmicrosoft.com" -azureAccountId "serviceadmin@contoso.onmicrosoft.com"
+.\RegisterWithAzure.ps1 -CloudAdminCredential $CloudAdminCredential -AzureSubscriptionId $SubscriptionId -JeaComputername "Azs-ERC01"
 
 .EXAMPLE
 
 This example registers your AzureStack account with Azure, enables syndication, and disables usage reporting to Azure. 
 
-.\RegisterWithAzure.ps1 -azureCredential $yourCredentials -azureSubscriptionId $subsciptionId -azureDirectoryTenantName "contoso.onmicrosoft.com" -azureAccountId "serviceadmin@contoso.onmicrosoft.com" -reportUsage:$false
+.\RegisterWithAzure.ps1 -CloudAdminCredential $CloudAdminCredential -AzureSubscriptionId $SubscriptionId -JeaComputername "Azs-ERC01" -UsageReportingEnabled:$false
+
+.EXAMPLE
+
+This example registers your AzureStack account with Azure, enables syndication and usage and gives a specific name to the resource group and registration resource. 
+
+.\RegisterWithAzure.ps1 -CloudAdminCredential $CloudAdminCredential -AzureSubscriptionId $SubscriptionId -JeaComputername "Prefix-ERCS01" -ResourceGroupName "ContosoStackRegistrations" -RegistrationName "Registration01"
+
+.EXAMPLE
+
+This example un-Registers by disabling syndication and stopping usage push to Azure. Note that usage will still be collected, just not pushed to Azure.
+
+.\RegisterWithAzure.ps1 -CloudAdminCredential $CloudAdminCredential -AzureSubscriptionId $SubscriptionId -JeaComputername "Azs-ERC01" -MarketplaceSyndicationEnabled:$false -UsageReportingEnabled:$false
 
 .NOTES
- Ensure that you have an Azure subscription and it is registered for Microsoft.AzureStack namespace in Azure.
- Namespace can be registered with the following command:
- Register-AzureRmResourceProvider -ProviderNamespace 'microsoft.azurestack' 
 
- If you would like to un-Register with you azure by turning off marketplace syndication and usage reporting you can run this script again with both enableSyndication
- and reportUsage set to false. This will unconfigure usage bridge so that syndication isn't possible and usage data is not reported. 
+If you would like to un-Register with you azure by turning off marketplace syndication and usage reporting you can run this script again with both enableSyndication
+and reportUsage set to false. This will unconfigure usage bridge so that syndication isn't possible and usage data is not reported.
+
+If you would like to use a different subscription for registration you must remove the activation resource from Azure and then re-run this script with a new subscription Id passed in.
 #>
-
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $false)]
-    [PSCredential] $azureCredential,
+    [Parameter(Mandatory = $true)]
+    [PSCredential] $CloudAdminCredential,
 
     [Parameter(Mandatory = $true)]
-    [String] $azureAccountId,
+    [String] $AzureSubscriptionId,
 
     [Parameter(Mandatory = $true)]
-    [String] $azureSubscriptionId,
-
-    [Parameter(Mandatory = $true)]
-    [String] $azureDirectoryTenantName,
+    [String] $JeaComputerName,
 
     [Parameter(Mandatory = $false)]
-    [String] $azureEnvironment = "AzureCloud",
+    [String] $ResourceGroupName = 'azurestack',
 
     [Parameter(Mandatory = $false)]
-    [String] $azureResourceManagerEndpoint = "https://management.azure.com",
+    [String] $ResourceGroupLocation = 'westcentralus',
 
     [Parameter(Mandatory = $false)]
-    [bool] $enableSyndication = $true,
+    [String] $RegistrationName,
 
     [Parameter(Mandatory = $false)]
-    [Switch] $reportUsage = $true
+    [String] $AzureEnvironmentName = 'AzureCloud',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateSet('Capacity', 'PayAsYouUse', 'Development')]
+    [string] $BillingModel = 'Development',
+
+    [Parameter(Mandatory=$false)]
+    [switch] $MarketplaceSyndicationEnabled = $true,
+
+    [Parameter(Mandatory=$false)]
+    [switch] $UsageReportingEnabled = $true,
+
+    [Parameter(Mandatory=$false)]
+    [ValidateNotNull()]
+    [string] $AgreementNumber
 )
+
 
 #requires -Module AzureRM.Profile
 #requires -Module AzureRM.Resources
-#requires -RunAsAdministrator
 
 $ErrorActionPreference = [System.Management.Automation.ActionPreference]::Stop
 $VerbosePreference = [System.Management.Automation.ActionPreference]::Continue
 
-Import-Module C:\CloudDeployment\ECEngine\EnterpriseCloudEngine.psd1 -Force
-Set-Location  C:\CloudDeployment\Setup\Activation\Bridge
+$profileVersion = [Version](Get-Module -Name AzureRM.Profile).Version
+$resourcesVersion = [Version](Get-Module -Name AzureRM.Resources).Version
+$maxVersion = [Version]"1.0.4.4"
 
-#
-# Pre-req: Version check
-#
-
-$versionInfo = [xml] (Get-Content -Path C:\CloudDeployment\Configuration\Version\version.xml) 
-$minVersion = "1.0.170501.1"
-if ($versionInfo.Version -lt $minVersion) {
-    Write-Error -Message "Script only applicable for Azure Stack builds $minVersion or later"
-}
-else {
-    Write-Verbose -Message "Running registration on build $($versionInfo.Version)" -Verbose
+if (($profileVersion -gt $maxVersion) -or ($resourcesVersion -gt $maxVersion))
+{
+    Write-Error "You are using an incompatible version of Powershell Module: AzureRm. Please use the version outlined here: `r`n https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-powershell-install"
 }
 
-#
-# Obtain refresh token for Azure identity
-#
+function Connect-AzureAccount
+{
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$SubscriptionId,
 
-Import-Module C:\CloudDeployment\Setup\Common\AzureADConfiguration.psm1 -ErrorAction Stop
-$AzureDirectoryTenantId = Get-TenantIdFromName -azureEnvironment $azureEnvironment -tenantName $azureDirectoryTenantName
+        [Parameter(Mandatory = $true)]
+        [string]$AzureEnvironmentName
+    )
 
-if (-not $azureCredential) {
-    Write-Verbose "Prompt user to enter Azure Credentials to get refresh token"
-    $tenantDetails = Get-AzureADTenantDetails -AzureEnvironment $azureEnvironment -AADDirectoryTenantName $azureDirectoryTenantName
-}
-else {
-    Write-Verbose "Using provided Azure Credentials to get refresh token"
-    $tenantDetails = Get-AzureADTenantDetails -AzureEnvironment $azureEnvironment -AADDirectoryTenantName $azureDirectoryTenantName -AADAdminCredential $azureCredential
-}
-
-$refreshToken = (ConvertTo-SecureString -string $tenantDetails["RefreshToken"] -AsPlainText -Force)
-
-#
-# Step 1: Configure Bridge identity
-#
-
-Write-Verbose "Calling Configure-BridgeIdentity.ps1"
-.\Configure-BridgeIdentity.ps1 -RefreshToken $refreshToken -AzureAccountId $azureAccountId -AzureDirectoryTenantName $azureDirectoryTenantName -AzureEnvironment $azureEnvironment -Verbose
-Write-Verbose "Configure Bridge identity completed"
-
-#
-# Step 2: Create new registration request
-#
-
-$bridgeAppConfigFile = "\\SU1FileServer\SU1_Infrastructure_1\ASResourceProvider\Config\AzureBridge.IdentityApplication.Configuration.json"
-$registrationOutputFile = "c:\temp\registration.json"
-
-Write-Verbose "Calling New-RegistrationRequest.ps1"
-.\New-RegistrationRequest.ps1 -BridgeAppConfigFile $bridgeAppConfigFile -RegistrationRequestOutputFile $registrationOutputFile -Verbose
-Write-Verbose "New registration request completed"
-
-#
-# Step 3: Register Azure Stack with Azure
-#
-
-New-Item -ItemType Directory -Force -Path "C:\temp"
-$registrationRequestFile = "c:\temp\registration.json"
-$registrationOutputFile = "c:\temp\registrationOutput.json"
-
-$timestamp = [DateTime]::Now.ToString("yyyyMMdd-HHmmss")
-$logPath = (New-Item -Path "$env:SystemDrive\CloudDeployment\Logs\" -ItemType Directory -Force).FullName
-$logFile = Join-Path -Path $logPath -ChildPath "Register-AzureStack.${timestamp}.txt"
-try { Start-Transcript -Path $logFile -Force | Out-String | Write-Verbose -Verbose } catch { Write-Warning -Message $_.Exception.Message }
-
-    Write-Verbose "Calling Register-AzureStack.ps1"
-    .\Register-AzureStack.ps1 -BillingModel PayAsYouUse -EnableSyndication -ReportUsage -SubscriptionId $azureSubscriptionId -AzureAdTenantId $AzureDirectoryTenantId `
-                                -RefreshToken $refreshToken -AzureAccountId $azureAccountId -AzureEnvironmentName $azureEnvironment -RegistrationRequestFile $registrationRequestFile `
-                                -RegistrationOutputFile $registrationOutputFile -Location "westcentralus" -Verbose
-    Write-Verbose "Register Azure Stack with Azure completed"
-
-try { Stop-Transcript -Verbose } catch { Write-Warning "$_" }
-
-#
-# workaround to enable syndication and usage
-#
-
-$activationDataFile = "c:\temp\regOutput2.json"
-$reg = Get-Content $registrationOutputFile | ConvertFrom-Json
-
-$newProps = @{
-    ObjectId          = $reg.properties.ObjectId
-    ProvisioningState = $reg.properties.provisioningState
-    enablesyndication = $enableSyndication
-    reportusage       = $reportUsage
-}
-
-$reg.properties = $newProps
-$reg | ConvertTo-Json -Depth 4 | Out-File -FilePath $activationDataFile
-
-Write-Verbose "Activation file is at : $activationDataFile"
-
-#
-# Step 4: Activate Azure Stack
-#
-$regResponse = Get-Content -path  $activationDataFile
-$bytes = [System.Text.Encoding]::UTF8.GetBytes($regResponse)
-$activationCode = [Convert]::ToBase64String($bytes)
-
-try {
-    .\Activate-Bridge.ps1 -activationCode $activationCode -AzureResourceManagerEndpoint $azureResourceManagerEndpoint -Verbose
-}
-catch {
-    $exceptionMessage = $_.Exception.Message
-
-    if($exceptionMessage.Contains("Application is currently being upgraded"))
+    $isConnected = $false;
+    
+    try
     {
-        Write-Warning "Activate-Bridge: Known issue with redundant service fabric upgrade call" 
+        $context = Get-AzureRmContext
+        $environment = Get-AzureRmEnvironment -Name $AzureEnvironmentName
+        $context.Environment = $environment
+        if ($context.Subscription.SubscriptionId -eq $SubscriptionId)
+        {
+            $isConnected = $true;
+        }
     }
-    else
+    catch
     {
-        Write-Error -Message "Activate-Bridge: Error : $($_.Exception)"
+        Write-Warning "Not currently connected to Azure: `r`n$($_.Exception)"
+    }
+
+    if (-not $isConnected)
+    {
+        Add-AzureRmAccount -SubscriptionId $SubscriptionId
+        $context = Get-AzureRmContext
+    }
+
+    $environment = Get-AzureRmEnvironment -Name $AzureEnvironmentName
+    $subscription = Get-AzureRmSubscription -SubscriptionId $SubscriptionId
+
+    $tokens = [Microsoft.IdentityModel.Clients.ActiveDirectory.TokenCache]::DefaultShared.ReadItems()
+    if (-not $tokens -or ($tokens.Count -le 0))
+    {
+            throw "Token cache is empty"
+    }
+
+    $token = $tokens |
+        Where Resource -EQ $environment.ActiveDirectoryServiceEndpointResourceId |
+        Where { $_.TenantId -eq $subscription.TenantId } |
+        Where { $_.ExpiresOn -gt [datetime]::UtcNow } |
+        Select -First 1
+
+    if (-not $token)
+    {
+        throw "Token not found for tenant id $($subscription.TenantId) and resource $($environment.ActiveDirectoryServiceEndpointResourceId)."
+    }
+
+    return @{
+        TenantId = $subscription.TenantId
+        ManagementEndpoint = $environment.ResourceManagerUrl
+        ManagementResourceId = $environment.ActiveDirectoryServiceEndpointResourceId
+        Token = $token
     }
 }
 
-Write-Verbose "Azure Stack activation completed"
+Write-Verbose "Logging in to Azure." -Verbose
+$connection = Connect-AzureAccount -SubscriptionId $AzureSubscriptionId -AzureEnvironment $AzureEnvironmentName
+
+Write-Verbose "Initializing privileged JEA session." -Verbose
+$session = New-PSSession -ComputerName $JeaComputerName -ConfigurationName PrivilegedEndpoint -Credential $CloudAdminCredential
+
+try
+{
+    Write-Verbose "Verifying stamp version." -Verbose
+    $stampInfo = Invoke-Command -Session $session -ScriptBlock { Get-AzureStackStampInformation -WarningAction SilentlyContinue }
+    $minVersion = "1.0.170626.1"
+    if ($stampInfo.StampVersion -lt $minVersion) {
+        Write-Error -Message "Script only applicable for Azure Stack builds $minVersion or later."
+    }
+
+    Write-Verbose -Message "Running registration on build $($stampInfo.StampVersion). Cloud Id: $($stampInfo.CloudID), Deployment Id: $($stampInfo.DeploymentID)" -Verbose
+
+    $tenantId = $connection.TenantId
+    Write-Verbose "Creating Azure Active Directory service principal in tenant: $tenantId." -Verbose
+    $refreshToken = $connection.Token.RefreshToken
+    $servicePrincipal = Invoke-Command -Session $session -ScriptBlock { New-AzureBridgeServicePrincipal -RefreshToken $using:refreshToken -AzureEnvironment $using:AzureEnvironmentName -TenantId $using:tenantId }
+
+    Write-Verbose "Creating registration token." -Verbose
+    $registrationToken = Invoke-Command -Session $session -ScriptBlock { New-RegistrationToken -BillingModel $using:BillingModel -MarketplaceSyndicationEnabled:$using:MarketplaceSyndicationEnabled -UsageReportingEnabled:$using:UsageReportingEnabled -AgreementNumber $using:AgreementNumber }
+
+    Write-Verbose "Creating resource group '$ResourceGroupName' in location $ResourceGroupLocation." -Verbose
+    $resourceGroup = New-AzureRmResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation -Force
+
+    Write-Verbose "Registering Azure Stack resource provider."
+    Register-AzureRmResourceProvider -ProviderNamespace "Microsoft.AzureStack" -Force | Out-Null
+
+    $RegistrationName = if ($RegistrationName) { $RegistrationName } else { "AzureStack-$($stampInfo.CloudID)" }
+
+    Write-Verbose "Creating registration resource '$RegistrationName'."
+    $registrationResource = New-AzureRmResource `
+        -ResourceGroupName $ResourceGroupName `
+        -Location westcentralus `
+        -ResourceName $RegistrationName `
+        -ResourceType "Microsoft.AzureStack/registrations" `
+        -Properties @{ registrationToken = "$registrationToken" } `
+        -ApiVersion "2017-06-01" `
+        -Force
+
+    Write-Verbose "Registration resource: $(ConvertTo-Json $registrationResource)"
+
+    Write-Verbose "Retrieving activation key."
+    $actionResponse = Invoke-AzureRmResourceAction `
+        -Action "getActivationKey" `
+        -ResourceName $RegistrationName `
+        -ResourceType "Microsoft.AzureStack/registrations" `
+        -ResourceGroupName $ResourceGroupName `
+        -ApiVersion "2017-06-01" `
+        -Force
+
+    Write-Verbose "Setting Registration Reader role on '$($registrationResource.ResourceId)' for service principal $($servicePrincipal.ObjectId)." -Verbose
+    $customRoleAssigned = $false
+    $customRoleName = "Registration Reader"
+    $roleAssignments = Get-AzureRmRoleAssignment -Scope "/subscriptions/$($registrationResource.SubscriptionId)/resourceGroups/$($registrationResource.ResourceGroupName)/providers/Microsoft.AzureStack/registrations/$($RegistrationName)" -ObjectId $servicePrincipal.ObjectId -ErrorAction SilentlyContinue
+    foreach ($role in $roleAssignments)
+    {
+        if ($role.RoleDefinitionName -eq $customRoleName)
+        {
+            $customRoleAssigned = $true
+        }
+    }
+
+    if (-not $roleAssignments -or (-not $customRoleAssigned))
+    {
+        $customRoleDefined = Get-AzureRmRoleDefinition -Name $customRoleName
+        if (-not $customRoleDefined)
+        {
+            # Create new RBAC role definition
+            $role = Get-AzureRmRoleDefinition -Name "Reader"
+            $role.Name = $customRoleName
+            $role.id = [guid]::newguid()
+            $role.IsCustom = $true
+            $role.Actions.Clear()            
+            $role.Actions.Add('Microsoft.AzureStack/registrations/products/listDetails/action')
+            $role.Actions.Add('Microsoft.AzureStack/registrations/products/read')            
+            $role.AssignableScopes.Clear()
+            $role.AssignableScopes.Add("/subscriptions/$($registrationResource.SubscriptionId)/resourceGroups/$($registrationResource.ResourceGroupName)/providers/Microsoft.AzureStack/registrations/$($RegistrationName)")
+            New-AzureRmRoleDefinition -Role $role
+        }
+        New-AzureRmRoleAssignment -Scope "/subscriptions/$($registrationResource.SubscriptionId)/resourceGroups/$($registrationResource.ResourceGroupName)/providers/Microsoft.AzureStack/registrations/$($RegistrationName)" -RoleDefinitionName $customRoleName -ObjectId $servicePrincipal.ObjectId         
+    }
+    
+    Write-Verbose "Activating Azure Stack (this may take several minutes to complete)." -Verbose
+    $activation = Invoke-Command -Session $session -ScriptBlock { New-AzureStackActivation -ActivationKey $using:actionResponse.ActivationKey }
+
+    Write-Verbose "Azure Stack registration and activation completed successfully." -Verbose
+}
+finally
+{
+    $session | Remove-PSSession
+}


### PR DESCRIPTION
Differs from brbartle/newregistrationflow in a few ways:

- Minor typo fixes in documentation
- Updates version checking to use strongly typed [version]
- Sets AzureEnvironmentName before attempting to get the current context
- Creates custom RBAC role for reading registrations and products in Azure Stack
    - This gets assigned to the resource itself. 
    - If not defined on that specific resource, the RBAC role will be created and then defined
