### PR TITLE
Correcting VPN Connection Route to include entire public VIP range

### DIFF
--- a/Connect/AzureStack.Connect.psm1
+++ b/Connect/AzureStack.Connect.psm1
@@ -37,7 +37,7 @@ function Add-AzsVpnConnection {
     $connection = Add-VpnConnection -Name $ConnectionName -ServerAddress $ServerAddress -TunnelType L2tp -EncryptionLevel Required -AuthenticationMethod MSChapv2 -L2tpPsk $PlainPassword -Force -RememberCredential -PassThru -SplitTunneling 
     
     Write-Verbose "Adding routes to Azure Stack VPN connection named $ConnectionName" -Verbose
-    Add-VpnConnectionRoute -ConnectionName $ConnectionName -DestinationPrefix 192.168.102.0/27 -RouteMetric 2 -PassThru | Out-Null
+    Add-VpnConnectionRoute -ConnectionName $ConnectionName -DestinationPrefix 192.168.102.0/24 -RouteMetric 2 -PassThru | Out-Null
     Add-VpnConnectionRoute -ConnectionName $ConnectionName -DestinationPrefix 192.168.105.0/27 -RouteMetric 2 -PassThru | Out-Null
 
     return $connection


### PR DESCRIPTION
The current code incorrectly sets the route statement for the public VIP pool resulting in user that VPN in not being able to get to all Public IPs that may be assigned to resources in their Azure Stack Environment.  The public VIP pool is a /24 not a /27 so the route statement that is added to the VPN connection needs to reflect this.