### PR TITLE
Removing -Scope CurrentUser from rm files.

### DIFF
--- a/CanaryValidator/README.md
+++ b/CanaryValidator/README.md
@@ -15,9 +15,9 @@ Set-Location -Path ".\AzureStack-Tools-master\CanaryValidator" -PassThru
 ## To execute Canary as Tenant Administrator (if Windows Server 2016 or Windows Server 2012-R2 images are already present in the PIR)
 
 ```powershell
-# Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-# Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-# Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+# Install-Module -Name 'AzureRm.Bootstrapper'
+# Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+# Install-Module -Name AzureStack -RequiredVersion 1.2.10
 $TenantAdminCreds =  New-Object System.Management.Automation.PSCredential "<Tenant Admin username>", (ConvertTo-SecureString "<Tenant Admin password>" -AsPlainText -Force)
 $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Service Admin username>", (ConvertTo-SecureString "<Service Admin password>" -AsPlainText -Force)
 .\Canary.Tests.ps1  -TenantID "<TenantID from Azure Active Directory>" -AdminArmEndpoint "<Administrative ARM endpoint>" -ServiceAdminCredentials $ServiceAdminCreds -TenantArmEndpoint "<Tenant ARM endpoint>" -TenantAdminCredentials $TenantAdminCreds
@@ -27,9 +27,9 @@ $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Ser
 
 ```powershell
 # Download the WS2016 ISO image from: https://www.microsoft.com/en-us/evalcenter/evaluate-windows-server-2016, and place it on your local machine
-# Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-# Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-# Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+# Install-Module -Name 'AzureRm.Bootstrapper'
+# Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+# Install-Module -Name AzureStack -RequiredVersion 1.2.10
 $TenantAdminCreds =  New-Object System.Management.Automation.PSCredential "<Tenant Admin username>", (ConvertTo-SecureString "<Tenant Admin password>" -AsPlainText -Force)
 $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Service Admin username>", (ConvertTo-SecureString "<Service Admin password>" -AsPlainText -Force)
 .\Canary.Tests.ps1  -TenantID "<TenantID from Azure Active Directory>" -AdminArmEndpoint "<Administrative ARM endpoint>" -ServiceAdminCredentials $ServiceAdminCreds -TenantArmEndpoint "<Tenant ARM endpoint>" -TenantAdminCredentials $TenantAdminCreds -WindowsISOPath "<path where the WS2016 ISO is present>"
@@ -38,9 +38,9 @@ $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Ser
 ## To execute Canary as Service Administrator
 
 ```powershell
-# Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-# Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-# Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+# Install-Module -Name 'AzureRm.Bootstrapper'
+# Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+# Install-Module -Name AzureStack -RequiredVersion 1.2.10
 $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Service Admin username>", (ConvertTo-SecureString "<Service Admin password>" -AsPlainText -Force)
 .\Canary.Tests.ps1 -TenantID "<TenantID from Azure Active Directory>" -AdminArmEndpoint "<Administrative ARM endpoint>" -ServiceAdminCredentials $ServiceAdminCreds
 ```
@@ -48,9 +48,9 @@ $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Ser
 ## To list the usecases in Canary
 
 ```powershell
-# Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-# Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-# Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+# Install-Module -Name 'AzureRm.Bootstrapper'
+# Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+# Install-Module -Name AzureStack -RequiredVersion 1.2.10
 .\Canary.Tests.ps1 -ListAvailable
 
 Sample output:
@@ -134,9 +134,9 @@ List of scenarios in Canary:
 ## To exclude certain usecases from getting executed
 
 ```powershell
-# Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-# Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-# Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+# Install-Module -Name 'AzureRm.Bootstrapper'
+# Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+# Install-Module -Name AzureStack -RequiredVersion 1.2.10
 # A new paramter called ExclusionList has been added which is a string array. Pass in the list of usecases you don't want to execute to this parameter.
 $ServiceAdminCreds =  New-Object System.Management.Automation.PSCredential "<Service Admin username>", (ConvertTo-SecureString "<Service Admin password>" -AsPlainText -Force)
 .\Canary.Tests.ps1 -TenantID "<TenantID from Azure Active Directory>" -AdminArmEndpoint "<Administrative ARM endpoint>" -ServiceAdminCredentials $ServiceAdminCreds -ExclusionList "ListFabricResourceProviderInfo","ListUpdateResourceProviderInfo"

--- a/ComputeAdmin/README.md
+++ b/ComputeAdmin/README.md
@@ -7,9 +7,9 @@ Instructions below are relative to the .\ComputeAdmin folder of the [AzureStack-
 Make sure you have the following module prerequisites installed:
 
 ```powershell
-Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper'
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+Install-Module -Name AzureStack -RequiredVersion 1.2.10
 ```
 
 Then make sure the following modules are imported:

--- a/Connect/README.md
+++ b/Connect/README.md
@@ -3,9 +3,9 @@
 As a prerequisite, make sure that you installed the correct PowerShell modules and versions:
 
 ```powershell
-Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper'
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+Install-Module -Name AzureStack -RequiredVersion 1.2.10
 ```
 
 This tool set allows you to connect to an Azure Stack Development Kit (ASDK) instance from an external personal laptop. You can then access the portal or log into that environment via PowerShell.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ To use these tools, obtain Azure Stack compatible Azure PowerShell module. Unles
 For PowerShell, install the following:
 
 ```powershell
-Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper'
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+Install-Module -Name AzureStack -RequiredVersion 1.2.10
 ```
 
 Obtain the tools by cloning the git repository.

--- a/ServiceAdmin/README.md
+++ b/ServiceAdmin/README.md
@@ -5,9 +5,9 @@ Instructions below are relative to the .\ServiceAdmin folder of the [AzureStack-
 Make sure you have the following module prerequisites installed:
 
 ```powershell
-Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.10 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper'
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+Install-Module -Name AzureStack -RequiredVersion 1.2.10
 ```
 
 Then make sure the following modules are imported:

--- a/Usage/README.md
+++ b/Usage/README.md
@@ -3,9 +3,9 @@
 As a prerequisite, make sure that you installed the correct PowerShell modules and versions:
 
 ```powershell
-Install-Module -Name 'AzureRm.Bootstrapper' -Scope CurrentUser
-Install-AzureRmProfile -profile '2017-03-09-profile' -Force -Scope CurrentUser
-Install-Module -Name AzureStack -RequiredVersion 1.2.9 -Scope CurrentUser
+Install-Module -Name 'AzureRm.Bootstrapper'
+Install-AzureRmProfile -profile '2017-03-09-profile' -Force
+Install-Module -Name AzureStack -RequiredVersion 1.2.10
 ```
 
 Use this script to extract usage data from the AzureStack Usage API's and export it to a CSV file


### PR DESCRIPTION
I believe these files were not using LR line endings except ComputeAdmin/README.md.

Now they are which is consistent. 