### PR TITLE
add multitenancy unregistration

### DIFF
--- a/Identity/AzureStack.Identity.psm1
+++ b/Identity/AzureStack.Identity.psm1
@@ -63,7 +63,7 @@ function New-AzsAdGraphServicePrincipal {
     $graphRedirectUri = "https://localhost/".ToLowerInvariant()
     $ApplicationName = $ApplicationGroupName
     $application = Invoke-Command -Session $domainAdminSession -Verbose -ErrorAction Stop  `
-            -ScriptBlock { New-GraphApplication -Name $using:ApplicationName  -ClientRedirectUris $using:graphRedirectUri -ClientCertificates $using:GraphClientCertificate }
+        -ScriptBlock { New-GraphApplication -Name $using:ApplicationName  -ClientRedirectUris $using:graphRedirectUri -ClientCertificates $using:GraphClientCertificate }
     
     return $application
 }
@@ -104,7 +104,7 @@ function Register-AzsGuestDirectoryTenant {
         [string[]] $GuestDirectoryTenantName,
 
         # The location of your Azure Stack deployment.
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $Location,
 
@@ -117,7 +117,7 @@ function Register-AzsGuestDirectoryTenant {
         [string] $SubscriptionName = $null,
 
         # The name of the resource group in which the directory tenant registration resource should be created (resource group must already exist).
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $ResourceGroupName = $null,
 
@@ -133,14 +133,12 @@ function Register-AzsGuestDirectoryTenant {
     # Install-Module AzureRm -RequiredVersion '1.2.11'
     Import-Module 'AzureRm.Profile' -Verbose:$false 4> $null
 
-    function Invoke-Main
-    {
+    function Invoke-Main {
         # Initialize the Azure PowerShell module to communicate with Azure Stack. Will prompt user for credentials.
         $azureEnvironment = Initialize-AzureRmEnvironment 'AzureStackAdmin'
-        $azureAccount     = Initialize-AzureRmUserAccount $azureEnvironment
+        $azureAccount = Initialize-AzureRmUserAccount $azureEnvironment
 
-        foreach ($directoryTenantName in $GuestDirectoryTenantName)
-        {
+        foreach ($directoryTenantName in $GuestDirectoryTenantName) {
             # Resolve the guest directory tenant ID from the name
             $directoryTenantId = (New-Object uri(Invoke-RestMethod "$($azureEnvironment.ActiveDirectoryAuthority.TrimEnd('/'))/$directoryTenantName/.well-known/openid-configuration").token_endpoint).AbsolutePath.Split('/')[1]
 
@@ -158,8 +156,7 @@ function Register-AzsGuestDirectoryTenant {
         }
     }
 
-    function Initialize-AzureRmEnvironment([string]$environmentName)
-    {
+    function Initialize-AzureRmEnvironment([string]$environmentName) {
         $endpoints = Invoke-RestMethod -Method Get -Uri "$($AdminResourceManagerEndpoint.ToString().TrimEnd('/'))/metadata/endpoints?api-version=2015-01-01" -Verbose
         Write-Verbose -Message "Endpoints: $(ConvertTo-Json $endpoints)" -Verbose
 
@@ -171,7 +168,7 @@ function Register-AzsGuestDirectoryTenant {
             ActiveDirectoryEndpoint                  = $endpoints.authentication.loginEndpoint.TrimEnd('/') + "/"
             ActiveDirectoryServiceEndpointResourceId = $endpoints.authentication.audiences[0]
             AdTenant                                 = $directoryTenantId
-            ResourceManagerEndpoint                  = $ResourceManagerEndpoint
+            ResourceManagerEndpoint                  = $AdminResourceManagerEndpoint
             GalleryEndpoint                          = $endpoints.galleryEndpoint
             GraphEndpoint                            = $endpoints.graphEndpoint
             GraphAudience                            = $endpoints.graphEndpoint
@@ -183,15 +180,13 @@ function Register-AzsGuestDirectoryTenant {
         return $azureEnvironment
     }
 
-    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment)
-    {
+    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment) {
         $params = @{
             EnvironmentName = $azureEnvironment.Name
             TenantId        = $azureEnvironment.AdTenant
         }
 
-        if ($AutomationCredential)
-        {
+        if ($AutomationCredential) {
             $params += @{ Credential = $AutomationCredential }
         }
 
@@ -199,12 +194,10 @@ function Register-AzsGuestDirectoryTenant {
         #$DebugPreference = "Continue"
         $azureAccount = Add-AzureRmAccount @params
 
-        if ($SubscriptionName)
-        {
+        if ($SubscriptionName) {
             Select-AzureRmSubscription -SubscriptionName $SubscriptionName | Out-Null
         }
-        elseif ($SubscriptionId)
-        {
+        elseif ($SubscriptionId) {
             Select-AzureRmSubscription -SubscriptionId $SubscriptionId  | Out-Null
         }
 
@@ -255,13 +248,12 @@ function Register-AzsWithMyDirectoryTenant {
     Import-Module 'AzureRm.Profile' -Verbose:$false 4> $null
     Import-Module "$PSScriptRoot\GraphAPI\GraphAPI.psm1" -Verbose:$false 4> $null
 
-    function Invoke-Main
-    {
+    function Invoke-Main {
         # Initialize the Azure PowerShell module to communicate with the Azure Resource Manager in the public cloud corresponding to the Azure Stack Graph Service. Will prompt user for credentials.
         Write-Host "Authenticating user..."
         $azureStackEnvironment = Initialize-AzureRmEnvironment 'AzureStack'
-        $azureEnvironment      = Resolve-AzureEnvironment $azureStackEnvironment
-        $refreshToken          = Initialize-AzureRmUserAccount $azureEnvironment $azureStackEnvironment.AdTenant
+        $azureEnvironment = Resolve-AzureEnvironment $azureStackEnvironment
+        $refreshToken = Initialize-AzureRmUserAccount $azureEnvironment $azureStackEnvironment.AdTenant
 
         # Initialize the Graph PowerShell module to communicate with the correct graph service
         $graphEnvironment = Resolve-GraphEnvironment $azureEnvironment
@@ -290,22 +282,19 @@ function Register-AzsWithMyDirectoryTenant {
         # Identify which permissions have already been granted to each registered application and which additional permissions need to be granted
         $permissions = @()
         $count = 0
-        foreach ($applicationRegistration in $applicationRegistrations)
-        {
+        foreach ($applicationRegistration in $applicationRegistrations) {
             # Initialize the service principal for the registered application
             $count++
             $applicationServicePrincipal = Initialize-GraphApplicationServicePrincipal -ApplicationId $applicationRegistration.appId
             Write-Host "Installing Application... ($($count) of $($applicationRegistrations.Count)): $($applicationServicePrincipal.appId) '$($applicationServicePrincipal.appDisplayName)'"
 
             # Initialize the necessary tags for the registered application
-            if ($applicationRegistration.tags)
-            {
+            if ($applicationRegistration.tags) {
                 Update-GraphApplicationServicePrincipalTags -ApplicationId $applicationRegistration.appId -Tags $applicationRegistration.tags
             }
 
             # Lookup the permission consent status for the *application* permissions (either to or from) which the registered application requires
-            foreach($appRoleAssignment in $applicationRegistration.appRoleAssignments)
-            {
+            foreach ($appRoleAssignment in $applicationRegistration.appRoleAssignments) {
                 $params = @{
                     ClientApplicationId   = $appRoleAssignment.client
                     ResourceApplicationId = $appRoleAssignment.resource
@@ -316,11 +305,9 @@ function Register-AzsWithMyDirectoryTenant {
             }
 
             # Lookup the permission consent status for the *delegated* permissions (either to or from) which the registered application requires
-            foreach($oauth2PermissionGrant in $applicationRegistration.oauth2PermissionGrants)
-            {
+            foreach ($oauth2PermissionGrant in $applicationRegistration.oauth2PermissionGrants) {
                 $resourceApplicationServicePrincipal = Initialize-GraphApplicationServicePrincipal -ApplicationId $oauth2PermissionGrant.resource
-                foreach ($scope in $oauth2PermissionGrant.scope.Split(' '))
-                {
+                foreach ($scope in $oauth2PermissionGrant.scope.Split(' ')) {
                     $params = @{
                         ClientApplicationId                 = $oauth2PermissionGrant.client
                         ResourceApplicationServicePrincipal = $resourceApplicationServicePrincipal
@@ -335,46 +322,39 @@ function Register-AzsWithMyDirectoryTenant {
         # Trace the permission status
         Write-Verbose "Current permission status: $($permissions | ConvertTo-Json -Depth 4)" -Verbose
 
-        $permissionFile    = Join-Path -Path $PSScriptRoot -ChildPath "$DirectoryTenantName.permissions.json"
+        $permissionFile = Join-Path -Path $PSScriptRoot -ChildPath "$DirectoryTenantName.permissions.json"
         $permissionContent = $permissions | Select -Property * -ExcludeProperty isConsented | ConvertTo-Json -Depth 4 | Out-String
         $permissionContent > $permissionFile
 
         # Display application status to user
-        $permissionsByClient = $permissions | Select *,@{n='Client';e={'{0} {1}' -f $_.clientApplicationId, $_.clientApplicationDisplayName}} | Sort clientApplicationDisplayName | Group Client
-        $readyApplications   = @()
+        $permissionsByClient = $permissions | Select *, @{n = 'Client'; e = {'{0} {1}' -f $_.clientApplicationId, $_.clientApplicationDisplayName}} | Sort clientApplicationDisplayName | Group Client
+        $readyApplications = @()
         $pendingApplications = @()
-        foreach ($client in $permissionsByClient)
-        {
-            if ($client.Group.isConsented -Contains $false)
-            {
+        foreach ($client in $permissionsByClient) {
+            if ($client.Group.isConsented -Contains $false) {
                 $pendingApplications += $client
             }
-            else
-            {
+            else {
                 $readyApplications += $client
             }
         }
 
         Write-Host ""
-        if ($readyApplications)
-        {
+        if ($readyApplications) {
             Write-Host "Applications installed and configured:"
             Write-Host "`t$($readyApplications.Name -join "`r`n`t")"
         }
-        if ($readyApplications -and $pendingApplications)
-        {
+        if ($readyApplications -and $pendingApplications) {
             Write-Host ""
         }
-        if ($pendingApplications)
-        {
+        if ($pendingApplications) {
             Write-Host "Applications waiting to be configured:"
             Write-Host "`t$($pendingApplications.Name -join "`r`n`t")"
         }
         Write-Host ""
 
         # Grant any missing permissions for registered applications
-        if ($permissions | Where isConsented -EQ $false | Select -First 1)
-        {
+        if ($permissions | Where isConsented -EQ $false | Select -First 1) {
             Write-Host "Configuring applications... (this may take up to a few minutes to complete)"
             Write-Host ""
             $permissions | Where isConsented -EQ $false | Grant-GraphApplicationPermission
@@ -387,8 +367,7 @@ function Register-AzsWithMyDirectoryTenant {
         Write-Warning "If your Azure Stack Administrator installs new services or updates in the future, you may need to run this script again."
     }
 
-    function Initialize-AzureRmEnvironment([string]$environmentName)
-    {
+    function Initialize-AzureRmEnvironment([string]$environmentName) {
         $endpoints = Invoke-RestMethod -Method Get -Uri "$($TenantResourceManagerEndpoint.ToString().TrimEnd('/'))/metadata/endpoints?api-version=2015-01-01" -Verbose
         Write-Verbose -Message "Endpoints: $(ConvertTo-Json $endpoints)" -Verbose
 
@@ -400,7 +379,7 @@ function Register-AzsWithMyDirectoryTenant {
             ActiveDirectoryEndpoint                  = $endpoints.authentication.loginEndpoint.TrimEnd('/') + "/"
             ActiveDirectoryServiceEndpointResourceId = $endpoints.authentication.audiences[0]
             AdTenant                                 = $directoryTenantId
-            ResourceManagerEndpoint                  = $ResourceManagerEndpoint
+            ResourceManagerEndpoint                  = $TenantResourceManagerEndpoint
             GalleryEndpoint                          = $endpoints.galleryEndpoint
             GraphEndpoint                            = $endpoints.graphEndpoint
             GraphAudience                            = $endpoints.graphEndpoint
@@ -412,15 +391,13 @@ function Register-AzsWithMyDirectoryTenant {
         return $azureEnvironment
     }
 
-    function Resolve-AzureEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureStackEnvironment)
-    {
+    function Resolve-AzureEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureStackEnvironment) {
         $azureEnvironment = Get-AzureRmEnvironment |
             Where GraphEndpointResourceId -EQ $azureStackEnvironment.GraphEndpointResourceId |
-            Where Name -In @('AzureCloud','AzureChinaCloud','AzureUSGovernment','AzureGermanCloud')
+            Where Name -In @('AzureCloud', 'AzureChinaCloud', 'AzureUSGovernment', 'AzureGermanCloud')
 
         # Differentiate between AzureCloud and AzureUSGovernment
-        if ($azureEnvironment.Count -ge 2)
-        {
+        if ($azureEnvironment.Count -ge 2) {
             $name = if ($azureStackEnvironment.ActiveDirectoryAuthority -eq 'https://login-us.microsoftonline.com/') { 'AzureUSGovernment' } else { 'AzureCloud' }
             $azureEnvironment = $azureEnvironment | Where Name -EQ $name
         }
@@ -428,15 +405,13 @@ function Register-AzsWithMyDirectoryTenant {
         return $azureEnvironment
     }
 
-    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment, [string]$directoryTenantId)
-    {
+    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment, [string]$directoryTenantId) {
         $params = @{
             EnvironmentName = $azureEnvironment.Name
             TenantId        = $directoryTenantId
         }
 
-        if ($AutomationCredential)
-        {
+        if ($AutomationCredential) {
             $params += @{ Credential = $AutomationCredential }
         }
 
@@ -458,14 +433,12 @@ function Register-AzsWithMyDirectoryTenant {
         return $refreshToken
     }
 
-    function Resolve-GraphEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment)
-    {
-        $graphEnvironment = switch($azureEnvironment.ActiveDirectoryAuthority)
-        {
-            'https://login.microsoftonline.com/'    { 'AzureCloud'        }
-            'https://login.chinacloudapi.cn/'       { 'AzureChinaCloud'   }
+    function Resolve-GraphEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment) {
+        $graphEnvironment = switch ($azureEnvironment.ActiveDirectoryAuthority) {
+            'https://login.microsoftonline.com/' { 'AzureCloud'        }
+            'https://login.chinacloudapi.cn/' { 'AzureChinaCloud'   }
             'https://login-us.microsoftonline.com/' { 'AzureUSGovernment' }
-            'https://login.microsoftonline.de/'     { 'AzureGermanCloud'  }
+            'https://login.microsoftonline.de/' { 'AzureGermanCloud'  }
 
             Default { throw "Unsupported graph resource identifier: $_" }
         }
@@ -473,8 +446,7 @@ function Register-AzsWithMyDirectoryTenant {
         return $graphEnvironment
     }
 
-    function Initialize-ResourceManagerServicePrincipal
-    {
+    function Initialize-ResourceManagerServicePrincipal {
         $identityInfo = Invoke-RestMethod -Method Get -Uri "$($TenantResourceManagerEndpoint.ToString().TrimEnd('/'))/metadata/identity?api-version=2015-01-01" -Verbose
         Write-Verbose -Message "Resource Manager identity information: $(ConvertTo-Json $identityInfo)" -Verbose
 
@@ -483,23 +455,18 @@ function Register-AzsWithMyDirectoryTenant {
         return $resourceManagerServicePrincipal
     }
 
-    function Get-ArmAccessToken([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureStackEnvironment)
-    {
+    function Get-ArmAccessToken([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureStackEnvironment) {
         $armAccessToken = $null
-        $attempts       = 0
-        $maxAttempts    = 12
+        $attempts = 0
+        $maxAttempts = 12
         $delayInSeconds = 5
-        do
-        {
-            try
-            {
+        do {
+            try {
                 $attempts++
                 $armAccessToken = (Get-GraphToken -Resource $azureStackEnvironment.ActiveDirectoryServiceEndpointResourceId -UseEnvironmentData -ErrorAction Stop).access_token
             }
-            catch
-            {
-                if ($attempts -ge $maxAttempts)
-                {
+            catch {
+                if ($attempts -ge $maxAttempts) {
                     throw
                 }
                 Write-Verbose "Error attempting to acquire ARM access token: $_`r`n$($_.Exception)" -Verbose
@@ -507,7 +474,7 @@ function Register-AzsWithMyDirectoryTenant {
                 Start-Sleep -Seconds $delayInSeconds
             }
         }
-        while(-not $armAccessToken)
+        while (-not $armAccessToken)
 
         return $armAccessToken
     }
@@ -518,16 +485,14 @@ function Register-AzsWithMyDirectoryTenant {
     $logStartMessage = "[$(Get-Date -Format 'hh:mm:ss tt')] - Beginning invocation of '$($MyInvocation.InvocationName)' with parameters: $(ConvertTo-Json $PSBoundParameters -Depth 4)"
     $logStartMessage >> $logFile
 
-    try
-    {
+    try {
         # Redirect verbose output to a log file
         Invoke-Main 4>> $logFile
 
         $logEndMessage = "[$(Get-Date -Format 'hh:mm:ss tt')] - Script completed successfully."
         $logEndMessage >> $logFile
     }
-    catch
-    {
+    catch {
         $logErrorMessage = "[$(Get-Date -Format 'hh:mm:ss tt')] - Script terminated with error: $_`r`n$($_.Exception)"
         $logErrorMessage >> $logFile
         Write-Warning "An error has occurred; more information may be found in the log file '$logFile'" -WarningAction Continue
@@ -555,20 +520,25 @@ function Unregister-AzsGuestDirectoryTenant {
     param
     (
         # The endpoint of the Azure Stack Resource Manager service.
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNull()]
-        [ValidateScript({$_.Scheme -eq [System.Uri]::UriSchemeHttps})]
+        [ValidateScript( {$_.Scheme -eq [System.Uri]::UriSchemeHttps})]
         [uri] $AdminResourceManagerEndpoint,
 
         # The name of the home Directory Tenant in which the Azure Stack Administrator subscription resides.
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $DirectoryTenantName,
 
         # The name of the guest Directory Tenant which is to be decommissioned.
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [string] $GuestDirectoryTenantName,
+
+        # The name of the resource group in which the directory tenant resource was created.
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string] $ResourceGroupName = $null,
 
         # The identifier of the Administrator Subscription. If not specified, the script will attempt to use the set default subscription.
         [Parameter()]
@@ -579,10 +549,6 @@ function Unregister-AzsGuestDirectoryTenant {
         [Parameter()]
         [ValidateNotNull()]
         [string] $SubscriptionName = $null,
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [string] $ResourceGroupName = 'system',
 
         # Optional: A credential used to authenticate with Azure Stack. Must support a non-interactive authentication flow. If not provided, the script will prompt for user credentials.
         [Parameter()]
@@ -598,13 +564,12 @@ function Unregister-AzsGuestDirectoryTenant {
     # Install-Module AzureRm
     Import-Module 'AzureRm.Profile' -Verbose:$false 4> $null
 
-    function Invoke-Main
-    {
+    function Invoke-Main {
         Write-DecommissionImplicationsWarning
 
         # Initialize the Azure PowerShell module to communicate with Azure Stack. Will prompt user for credentials.
         $azureEnvironment = Initialize-AzureRmEnvironment 'AzureStackAdmin'
-        $azureAccount     = Initialize-AzureRmUserAccount $azureEnvironment
+        $azureAccount = Initialize-AzureRmUserAccount $azureEnvironment
 
         # Remove the new directory tenant to the Azure Stack deployment
         $params = @{
@@ -615,8 +580,7 @@ function Unregister-AzsGuestDirectoryTenant {
         Write-Verbose -Message "Directory Tenant decommissioned: $($params.ResourceId)" -Verbose
     }
 
-    function Initialize-AzureRmEnvironment([string]$environmentName)
-    {
+    function Initialize-AzureRmEnvironment([string]$environmentName) {
         $endpoints = Invoke-RestMethod -Method Get -Uri "$($ResourceManagerEndpoint.ToString().TrimEnd('/'))/metadata/endpoints?api-version=2015-01-01" -Verbose
         Write-Verbose -Message "Endpoints: $(ConvertTo-Json $endpoints)" -Verbose
 
@@ -640,35 +604,30 @@ function Unregister-AzsGuestDirectoryTenant {
         return $azureEnvironment
     }
 
-    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment)
-    {
+    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment) {
         $params = @{
             EnvironmentName = $azureEnvironment.Name
             TenantId        = $azureEnvironment.AdTenant
         }
 
-        if ($AutomationCredential)
-        {
+        if ($AutomationCredential) {
             $params += @{ Credential = $AutomationCredential }
         }
 
         # Prompts the user for interactive login flow if automation credential is not specified
         $azureAccount = Add-AzureRmAccount @params
 
-        if ($SubscriptionName)
-        {
+        if ($SubscriptionName) {
             Select-AzureRmSubscription -SubscriptionName $SubscriptionName | Out-Null
         }
-        elseif ($SubscriptionId)
-        {
+        elseif ($SubscriptionId) {
             Select-AzureRmSubscription -SubscriptionId $SubscriptionId  | Out-Null
         }
 
         return $azureAccount
     }
 
-    function Write-DecommissionImplicationsWarning
-    {
+    function Write-DecommissionImplicationsWarning {
         $params = @{
             Message       = ''
             WarningAction = 'Inquire'
@@ -678,12 +637,10 @@ function Unregister-AzsGuestDirectoryTenant {
         $params.Message += " Additionally, you should first ensure that an Administrator of the directory '$directoryTenantName' has completed their decommissioning process before removing this access"
         $params.Message += ' (they will need to query your Azure Stack deployment to see which identities need to be removed from their directory).'
 
-        if ($AutomationCredential)
-        {
+        if ($AutomationCredential) {
             $params.WarningAction = 'Continue'
         }
-        else
-        {
+        else {
             $params.Message += " Would you like to proceed?"
         }
 
@@ -736,15 +693,14 @@ function Unregister-AzsWithMyDirectoryTenant {
     Import-Module 'AzureRm.Profile' -Verbose:$false 4> $null
     Import-Module "$PSScriptRoot\GraphAPI\GraphAPI.psm1" -Verbose:$false 4> $null
     
-    function Invoke-Main
-    {
+    function Invoke-Main {
         Write-DecommissionImplicationsWarning
     
         # Initialize the Azure PowerShell module to communicate with the Azure Resource Manager in the public cloud corresponding to the Azure Stack Graph Service. Will prompt user for credentials.
         Write-Host "Authenticating user..."
         $azureStackEnvironment = Initialize-AzureRmEnvironment 'AzureStack'
-        $azureEnvironment      = Resolve-AzureEnvironment $azureStackEnvironment
-        $refreshToken          = Initialize-AzureRmUserAccount $azureEnvironment $azureStackEnvironment.AdTenant
+        $azureEnvironment = Resolve-AzureEnvironment $azureStackEnvironment
+        $refreshToken = Initialize-AzureRmUserAccount $azureEnvironment $azureStackEnvironment.AdTenant
     
         # Initialize the Graph PowerShell module to communicate with the correct graph service
         $graphEnvironment = Resolve-GraphEnvironment $azureEnvironment
@@ -763,16 +719,13 @@ function Unregister-AzsWithMyDirectoryTenant {
         $applicationRegistrations = Invoke-RestMethod @applicationRegistrationParams | Select -ExpandProperty value
     
         # Delete the service principals for the registered applications
-        foreach ($applicationRegistration in $applicationRegistrations)
-        {
-            if (($applicationServicePrincipal = Get-GraphApplicationServicePrincipal -ApplicationId $applicationRegistration.appId -ErrorAction Continue))
-            {
+        foreach ($applicationRegistration in $applicationRegistrations) {
+            if (($applicationServicePrincipal = Get-GraphApplicationServicePrincipal -ApplicationId $applicationRegistration.appId -ErrorAction Continue)) {
                 Write-Verbose "Uninstalling service principal: $(ConvertTo-Json $applicationServicePrincipal)" -Verbose
                 Remove-GraphObject -objectId $applicationServicePrincipal.objectId
                 Write-Host "Application '$($applicationServicePrincipal.appId)' ($($applicationServicePrincipal.appDisplayName)) was successfully uninstalled from your directory."
             }
-            else
-            {
+            else {
                 Write-Host "Application '$($applicationRegistration.appId)' is not installed or was already successfully uninstalled from your directory."
             }
         }
@@ -780,8 +733,7 @@ function Unregister-AzsWithMyDirectoryTenant {
         Write-Host "All Azure Stack applications have been uninstalled! Your directory '$DirectoryTenantName' has been successfully decommissioned and can no-longer be used with Azure Stack."
     }
     
-    function Initialize-AzureRmEnvironment([string]$environmentName)
-    {
+    function Initialize-AzureRmEnvironment([string]$environmentName) {
         $endpoints = Invoke-RestMethod -Method Get -Uri "$($ResourceManagerEndpoint.ToString().TrimEnd('/'))/metadata/endpoints?api-version=2015-01-01" -Verbose
         Write-Verbose -Message "Endpoints: $(ConvertTo-Json $endpoints)" -Verbose
     
@@ -805,15 +757,13 @@ function Unregister-AzsWithMyDirectoryTenant {
         return $azureEnvironment
     }
     
-    function Resolve-AzureEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureStackEnvironment)
-    {
+    function Resolve-AzureEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureStackEnvironment) {
         $azureEnvironment = Get-AzureRmEnvironment |
             Where GraphEndpointResourceId -EQ $azureStackEnvironment.GraphEndpointResourceId |
-            Where Name -In @('AzureCloud','AzureChinaCloud','AzureUSGovernment','AzureGermanCloud')
+            Where Name -In @('AzureCloud', 'AzureChinaCloud', 'AzureUSGovernment', 'AzureGermanCloud')
     
         # Differentiate between AzureCloud and AzureUSGovernment
-        if ($azureEnvironment.Count -ge 2)
-        {
+        if ($azureEnvironment.Count -ge 2) {
             $name = if ($azureStackEnvironment.ActiveDirectoryAuthority -eq 'https://login-us.microsoftonline.com/') { 'AzureUSGovernment' } else { 'AzureCloud' }
             $azureEnvironment = $azureEnvironment | Where Name -EQ $name
         }
@@ -821,15 +771,13 @@ function Unregister-AzsWithMyDirectoryTenant {
         return $azureEnvironment
     }
     
-    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment, [string]$directoryTenantId)
-    {
+    function Initialize-AzureRmUserAccount([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment, [string]$directoryTenantId) {
         $params = @{
             EnvironmentName = $azureEnvironment.Name
             TenantId        = $directoryTenantId
         }
     
-        if ($AutomationCredential)
-        {
+        if ($AutomationCredential) {
             $params += @{ Credential = $AutomationCredential }
         }
     
@@ -851,14 +799,12 @@ function Unregister-AzsWithMyDirectoryTenant {
         return $refreshToken
     }
     
-    function Resolve-GraphEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment)
-    {
-        $graphEnvironment = switch($azureEnvironment.ActiveDirectoryAuthority)
-        {
-            'https://login.microsoftonline.com/'    { 'AzureCloud'        }
-            'https://login.chinacloudapi.cn/'       { 'AzureChinaCloud'   }
+    function Resolve-GraphEnvironment([Microsoft.Azure.Commands.Profile.Models.PSAzureEnvironment]$azureEnvironment) {
+        $graphEnvironment = switch ($azureEnvironment.ActiveDirectoryAuthority) {
+            'https://login.microsoftonline.com/' { 'AzureCloud'        }
+            'https://login.chinacloudapi.cn/' { 'AzureChinaCloud'   }
             'https://login-us.microsoftonline.com/' { 'AzureUSGovernment' }
-            'https://login.microsoftonline.de/'     { 'AzureGermanCloud'  }
+            'https://login.microsoftonline.de/' { 'AzureGermanCloud'  }
     
             Default { throw "Unsupported graph resource identifier: $_" }
         }
@@ -866,8 +812,7 @@ function Unregister-AzsWithMyDirectoryTenant {
         return $graphEnvironment
     }
     
-    function Write-DecommissionImplicationsWarning
-    {
+    function Write-DecommissionImplicationsWarning {
         $params = @{
             Message       = ''
             WarningAction = 'Inquire'
@@ -875,12 +820,10 @@ function Unregister-AzsWithMyDirectoryTenant {
         $params.Message += 'You are removing access from an Azure Stack deployment to your directory tenant.'
         $params.Message += ' Users in your directory will be unable to access or manage any existing subscriptions in the Azure Stack deployment (access to any existing resources may be impaired if they require identity integration).'
     
-        if ($AutomationCredential)
-        {
+        if ($AutomationCredential) {
             $params.WarningAction = 'Continue'
         }
-        else
-        {
+        else {
             $params.Message += " Would you like to proceed?"
         }
     
@@ -893,16 +836,14 @@ function Unregister-AzsWithMyDirectoryTenant {
     $logStartMessage = "[$(Get-Date -Format 'hh:mm:ss tt')] - Beginning invocation of '$($MyInvocation.InvocationName)' with parameters: $(ConvertTo-Json $PSBoundParameters -Depth 4)"
     $logStartMessage >> $logFile
     
-    try
-    {
+    try {
         # Redirect verbose output to a log file
         Invoke-Main 4>> $logFile
     
         $logEndMessage = "[$(Get-Date -Format 'hh:mm:ss tt')] - Script completed successfully."
         $logEndMessage >> $logFile
     }
-    catch
-    {
+    catch {
         $logErrorMessage = "[$(Get-Date -Format 'hh:mm:ss tt')] - Script terminated with error: $_`r`n$($_.Exception)"
         $logErrorMessage >> $logFile
         Write-Warning "An error has occurred; more information may be found in the log file '$logFile'" -WarningAction Continue


### PR DESCRIPTION
Adds support for unregistering directory tenants which were "onboarded" or "registered" with Azure Stack. The Admin of the onboarded directory tenant runs a cmdlet to uninstall the currently-registered identity applications, and then the Azure Stack Admin runs a cmdlet to disallow authentication within that directory tenant (removes it from the whitelist of allowed directories). If the Admin inadvertently unregisters the directory first, they will have to re-register it before the guest Admin can uninstall the necessary applications. Note that if the guest Admin keeps the permissions.json log file produced when they initially registered (or subsequently ran the registration) they could manually delete the service principals referenced in that file.