### PR TITLE
Fix incorrect format for data disk URL

### DIFF
--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -186,7 +186,7 @@ function Add-AzsVMImage {
         if ($PSBoundParameters.ContainsKey('dataDisksLocalPaths')) {
             foreach ($dataDiskLocalPath in $dataDisksLocalPaths) {
                 $dataDiskName = Split-Path $dataDiskLocalPath -Leaf
-                $dataDiskBlobURI = "https://$storageAccountName.blob.$Domain/$containerName/$dataDiskName"
+                $dataDiskBlobURI = '{0}{1}/{2}' -f $storageAccount.PrimaryEndpoints.Blob.AbsoluteUri, $containerName, $dataDiskName
                 $dataDiskBlobURIsFromLocal.Add($dataDiskBlobURI) 
                 Add-AzureRmVhd  -Destination $dataDiskBlobURI -ResourceGroupName $resourceGroupName -LocalFilePath $dataDiskLocalPath -OverWrite
             }


### PR DESCRIPTION
Fix Bug: Add-AzsVMImage fails when data disks are included

The url used to upload data disks inside AzureStack.ComputeAdmin.psm1 is ill formed and fails consistently.
However uploading osdisk works.

Fix is to update the data disk URI.