### PR TITLE
Consistency with SKU parameter for Azure

### DIFF
--- a/ComputeAdmin/AzureStack.ComputeAdmin.psm1
+++ b/ComputeAdmin/AzureStack.ComputeAdmin.psm1
@@ -88,7 +88,7 @@ function Add-AzsVMImage {
     
         [Parameter(Mandatory = $true, ParameterSetName = 'VMImageFromLocal')]
         [Parameter(Mandatory = $true, ParameterSetName = 'VMImageFromAzure')]
-        [ValidatePattern("[a-zA-Z0-9-]{3,}")]
+        [ValidatePattern("[a-zA-Z0-9-\.]{3,}")]
         [String] $Sku,
     
         [Parameter(Mandatory = $true, ParameterSetName = 'VMImageFromLocal')]
@@ -331,7 +331,7 @@ function Remove-AzsVMImage {
         [String] $Offer,
     
         [Parameter(Mandatory = $true)]
-        [ValidatePattern("[a-zA-Z0-9-]{3,}")]
+        [ValidatePattern("[a-zA-Z0-9-\.]{3,}")]
         [String] $Sku,
     
         [Parameter(Mandatory = $true)]
@@ -406,7 +406,7 @@ function Get-AzsVMImage {
         [String] $Offer,
     
         [Parameter(Mandatory = $true)]
-        [ValidatePattern("[a-zA-Z0-9-]{3,}")]
+        [ValidatePattern("[a-zA-Z0-9-\.]{3,}")]
         [String] $Sku,
     
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
Solving issue:

https://github.com/Azure/AzureStack-Tools/issues/107

Azure allows the "." character for SKU but the current implementation of the validation pattern does not include this character. This pull request changes the regular expression to add this pattern.