### PR TITLE
Share IP may not be correctly detected

### DIFF
--- a/Support/ERCS_Logs/ERCS_AzureStackLogs.ps1
+++ b/Support/ERCS_Logs/ERCS_AzureStackLogs.ps1
@@ -787,6 +787,7 @@ if($IP)
 				{
 				$remoteip = $testconnect.RemoteAddress.IPAddressToString
 				$share = $testconnect.SourceAddress.IPAddress
+				$share = Read-InputBoxDialog -Message "Please enter upload share IP:" -WindowTitle "Log upload share IP:" -DefaultText $share
 				$myname = whoami
                 $date = Get-Date -format MM-dd-hhmm
                 $foldername = "-AzureStackLogs"


### PR DESCRIPTION
I am having issue while running from Azure stack where Public IP is not visible to VM. Hence 
$share = $testconnect.SourceAddress.IPAddress
may detect incorrect IP. I suggest to add line to eventually manualy overide the share IP.