### PR TITLE
[DO NOT MERGE until 1812] re removing bgpnat parameters & adding restore deployment support in installer

### DIFF
--- a/Deployment/asdk-installer.ps1
+++ b/Deployment/asdk-installer.ps1
@@ -41,8 +41,8 @@ $Text_SafeOS = @{}
 $Text_SafeOS.Mode_Title = "Prepare for Deployment"
 $Text_SafeOS.Mode_LeftTitle = "Prepare Environment"
 $Text_SafeOS.Mode_LeftContent = "Prepare the Cloudbuilder vhdx"
-$Text_SafeOS.Mode_RightTitle = "Online documentation"
-$Text_SafeOS.Mode_RightContent = "Read the online documentation."
+$Text_SafeOS.Mode_TopRightTitle = "Online documentation"
+$Text_SafeOS.Mode_TopRightContent = "Read the online documentation."
 $Text_SafeOS.Prepare_Title = "Select Cloudbuilder vhdx"
 $Text_SafeOS.Prepare_VHDX_IsMounted = "This vhdx is already mounted"
 $Text_SafeOS.Prepare_VHDX_InvalidPath = "Not a valid Path"
@@ -53,20 +53,23 @@ $Text_SafeOS.NetInterface_Warning = "Select the network interface that will be c
 $Text_SafeOS.NetConfig_Title = "Azure Stack host IP configuration"
 $Text_SafeOS.Job_Title = "Preparing the environment"
 $Text_SafeOS.Summary_Content = "The cloudbuilder vhdx is prepared succesfully. Please reboot. The server will boot from the CloudBuilder VHD and you can start the installation after signing in as the administrator."
-$Text_SafeOS.Mode_RightLink = "https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-run-powershell-script"
+$Text_SafeOS.Mode_TopRightLink = "https://docs.microsoft.com/en-us/azure/azure-stack/azure-stack-run-powershell-script"
 $Text_SafeOS.OS_Version = "The SafeOS must be running Windows Server 2016 or Windows 10 to use the ASDK Installer. Consider upgrading the SafeOS or use PowerShell to install the ASDK https://docs.microsoft.com/en-us/azure/azure-stack/asdk/asdk-deploy-powershell"
 
 $Text_Install = @{}
 $Text_Install.Mode_Title = "Installation"
 $Text_Install.Mode_LeftTitle = "Install"
 $Text_Install.Mode_LeftContent = "Install the Microsoft Azure Stack Development Kit"
-$Text_Install.Mode_RightTitle = "Reboot"
-$Text_Install.Mode_RightContent = "Select the Operating System to override the default boot order for this reboot."
+$Text_Install.Mode_BottomRightTitle = "Recover"
+$Text_Install.Mode_BottomRightContent = "Install the Micrsoft Azure Stack Deployment Kit in cloud recovery mode."
+$Text_Install.Mode_TopRightTitle = "Reboot"
+$Text_Install.Mode_TopRightContent = "Select the Operating System to override the default boot order for this reboot."
 $Text_Install.Reboot_Title = "Reboot"
 $Text_Install.NetInterface_Title = "Select Network Interface for the Azure Stack host"
 $Text_Install.NetInterface_Warning = "Only one adapter can be used for the Azure Stack Development Kit host. Select the adapter used for the deployment. All other adapters will be disabled by the installer. Ensure you have network connectivity to the selected network adapter before proceeding."
 $Text_Install.NetConfig_Title = "Network Configuration"
 $Text_Install.Credentials_Title = "Specify Identity Provider and Credentials"
+$Text_Install.Restore_Title = "Backup settings"
 $Text_Install.Summary_Title = "Summary"
 $Text_Install.Summary_Content = "The following script will be used for deploying the Development Kit"
 $Text_Install.Summary_Warning = "You will be prompted for your Azure AD credentials 2-3 minutes after the installation starts"
@@ -99,7 +102,7 @@ $Xaml = @'
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        Title="Microsoft Azure Stack Development Kit" Height="650" Width="664" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
+        Title="Microsoft Azure Stack Development Kit" Height="700" Width="664" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
     <Window.Resources>
         <!--#region window-->
         <Style TargetType="{x:Type Window}">
@@ -973,18 +976,26 @@ $Xaml = @'
                 <!--#region Mode-->
                 <StackPanel x:Name="Control_Mode_Stp" Visibility="Visible">
                     <StackPanel Orientation="Horizontal">
-                        <Button x:Name="Control_Mode_Btn_Left" Width="250" Height="250" Margin="0,0,50,0" AutomationProperties.LabeledBy="{Binding ElementName=Control_Mode_Tbl_LeftTitle}">
+                        <Button x:Name="Control_Mode_Btn_Left" Width="250" Height="300" AutomationProperties.LabeledBy="{Binding ElementName=Control_Mode_Tbl_LeftTitle}">
                             <StackPanel VerticalAlignment="Top">
                                 <TextBlock x:Name="Control_Mode_Tbl_LeftTitle" TextWrapping="Wrap" Padding="15" FontSize="18" FontFamily="Segoe UI" Text="LeftTitle" />
                                 <TextBlock x:Name="Control_Mode_Tbl_LeftContent" TextWrapping="Wrap" Padding="15,0,15,15" FontSize="14" FontFamily="Segoe UI" Text="LeftContent"/>
                             </StackPanel>
                         </Button>
-                        <Button x:Name="Control_Mode_Btn_Right" Width="250" Height="250" AutomationProperties.LabeledBy="{Binding ElementName=Control_Mode_Tbl_RightTitle}" >
-                            <StackPanel VerticalAlignment="Top">
-                                <TextBlock x:Name="Control_Mode_Tbl_RightTitle" TextWrapping="Wrap" Padding="15" FontSize="18" FontFamily="Segoe UI" Text="RightTitle" />
-                                <TextBlock x:Name="Control_Mode_Tbl_RightContent" TextWrapping="Wrap" Padding="15,0,15,15" FontSize="14" FontFamily="Segoe UI" Text="RightContent"/>
-                            </StackPanel>
-                        </Button>
+                        <Grid x:Name="Control_Mode_Btn_RightGrid" Width="250" Height="300" Margin="50,0,0,0">
+                            <Button x:Name="Control_Mode_Btn_TopRight" Width="250" VerticalAlignment="Stretch" AutomationProperties.LabeledBy="{Binding ElementName=Control_Mode_Tbl_TopRightTitle}" >
+                                <StackPanel VerticalAlignment="Top">
+                                    <TextBlock x:Name="Control_Mode_Tbl_TopRightTitle" TextWrapping="Wrap" Padding="15" FontSize="18" FontFamily="Segoe UI" Text="TopRightTitle" />
+                                    <TextBlock x:Name="Control_Mode_Tbl_TopRightContent" TextWrapping="Wrap" Padding="15,0,15,15" FontSize="14" FontFamily="Segoe UI" Text="TopRightContent"/>
+                                </StackPanel>
+                            </Button>
+                            <Button x:Name="Control_Mode_Btn_BottomRight" Width="250" VerticalAlignment="Bottom" AutomationProperties.LabeledBy="{Binding ElementName=Control_Mode_Tbl_BottomRightTitle}" Visibility="Collapsed">
+                                <StackPanel VerticalAlignment="Top">
+                                    <TextBlock x:Name="Control_Mode_Tbl_BottomRightTitle" TextWrapping="Wrap" Padding="15" FontSize="18" FontFamily="Segoe UI" Text="BottomRightTitle" />
+                                    <TextBlock x:Name="Control_Mode_Tbl_BottomRightContent" TextWrapping="Wrap" Padding="15,0,15,15" FontSize="14" FontFamily="Segoe UI" Text="BottomRightContent"/>
+                                </StackPanel>
+                            </Button>
+                        </Grid>
                     </StackPanel>
                     <TextBlock FontSize="11.5" FontFamily="Segoe UI Light" Padding="0,40,0,0" TextWrapping="Wrap" ><Run Text="The installer UI for the Azure Stack Development Kit is an open sourced script based on WPF and PowerShell. Additions to the toolkit can be submitted as Pull Request to the "/><Run Foreground="#879AAB" Text="AzureStack-Tools repository"/><Run Text="."/></TextBlock>
                 </StackPanel>
@@ -1053,7 +1064,7 @@ $Xaml = @'
                         <StackPanel x:Name="Control_Creds_Stp_AAD" Visibility="Visible">
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                                 <TextBlock x:Name="Control_Creds_Tbl_AADTenant" FontSize="14" FontFamily="Segoe UI"  Text="AAD Directory:" Width="120" HorizontalAlignment="Left"/>
-                                <TextBox x:Name="Control_Creds_Tbx_AADTenant" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Width="430"  IsEnabled="False" AutomationProperties.LabeledBy="{Binding ElementName=Control_Creds_Tbl_AADTenant}" />
+                                <TextBox x:Name="Control_Creds_Tbx_AADTenant" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Width="430" IsEnabled="False" AutomationProperties.LabeledBy="{Binding ElementName=Control_Creds_Tbl_AADTenant}" />
                             </StackPanel>
                         </StackPanel>
                         <StackPanel x:Name="Control_Creds_Stp_LocalPassword" Visibility="Visible">
@@ -1245,9 +1256,69 @@ $Xaml = @'
                     </StackPanel>
                 </StackPanel>
                 <!--#endregion Job-->
+                <!--#region Restore-->
+                <StackPanel x:Name="Control_Restore_Stp" HorizontalAlignment="Stretch" Visibility="Collapsed">
+                    <StackPanel Height="320" HorizontalAlignment="Stretch">
+                        <Grid x:Name="Control_Restore_Stp_BackupInfo" VerticalAlignment="Top" HorizontalAlignment="Stretch" Visibility="Visible">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock x:Name="Control_Restore_Tbl_BackupStorePath" FontSize="16" FontFamily="Segoe UI"
+                                        Text="Backup path:" HorizontalAlignment="Left" Grid.Row="0" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBox x:Name="Control_Restore_Tbx_BackupStorePath" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" 
+                                    AutomationProperties.LabeledBy="{Binding ElementName=Control_Restore_Tbl_BackupStorePath}"
+                                    Grid.Row="0" Grid.Column="1" Margin="0,10"/>
+                            
+                            <TextBlock x:Name="Control_Restore_Tbl_BackupStoreUserName" FontSize="16" FontFamily="Segoe UI" Text="Username:"
+                                        HorizontalAlignment="Left" Grid.Row="1" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBox x:Name="Control_Restore_Tbx_BackupStoreUserName" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" 
+                                    AutomationProperties.LabeledBy="{Binding ElementName=Control_Restore_Tbl_BackupStoreUserName}" Grid.Row="1" Grid.Column="1" Margin="0,10"/>
+                            
+                            <TextBlock x:Name="Control_Restore_Tbl_BackupStorePassword" FontSize="16" FontFamily="Segoe UI"
+                                    Text="Password:" Grid.Row="2" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <Grid Grid.Row="2" Grid.Column="1" Margin="0,10">
+                                <PasswordBox x:Name="Control_Restore_Pwb_BackupStorePassword" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                                            AutomationProperties.LabeledBy="{Binding ElementName=Control_Restore_Tbl_BackupStorePassword}" Grid.Column="0"/>
+                                <Path x:Name="Control_Restore_Pth_BackupStorePassword" SnapsToDevicePixels="False" StrokeThickness="3" Data="M2,10 L8,16 L15,5" Stroke="#92D050" Margin="300,0,0,0" Visibility="Hidden"/>
+                            </Grid>
+                            
+                            <TextBlock x:Name="Control_Restore_Tbl_BackupEncryptionKey" FontSize="16" FontFamily="Segoe UI" Text="Encryption key:" HorizontalAlignment="Left"
+                                    Grid.Row="3" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBox x:Name="Control_Restore_Tbx_BackupEncryptionKey" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                                    AutomationProperties.LabeledBy="{Binding ElementName=Control_Restore_Tbl_BackupEncryptionKey}" Grid.Row="3" Grid.Column="1" Margin="0,10"/>
+                            
+                            <TextBlock x:Name="Control_Restore_Tbl_BackupID" FontSize="16" FontFamily="Segoe UI" Text="Backup ID:" HorizontalAlignment="Left"
+                                    Grid.Row="4" Grid.Column="0" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <TextBox x:Name="Control_Restore_Tbx_BackupID" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                                    AutomationProperties.LabeledBy="{Binding ElementName=Control_Restore_Tbl_BackupID}" Grid.Row="4" Grid.Column="1" Margin="0,10"/>
+
+                            <TextBlock x:Name="Control_Restore_Tbl_ExternalCertPassword" FontSize="16" FontFamily="Segoe UI" Text="External Certificate Password:"
+                                    Grid.Row="5" Grid.Column="0" TextWrapping="Wrap" MaxWidth="150" VerticalAlignment="Center" Margin="0,0,10,0"/>
+                            <Grid Grid.Row="5" Grid.Column="1" Margin="0,10">
+                                <PasswordBox x:Name="Control_Restore_Pwb_ExternalCertPassword" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"
+                                            AutomationProperties.LabeledBy="{Binding ElementName=Control_Creds_Tbl_LocalAdminPassword}"/>
+                                <Path x:Name="Control_Restore_Pth_ExternalCertPassword" SnapsToDevicePixels="False" StrokeThickness="3" Data="M2,10 L8,16 L15,5" Stroke="#92D050" Margin="300,0,0,0" Visibility="Hidden"/>
+                            </Grid>
+                        </Grid>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <Button x:Name="Control_Restore_Btn_Previous" Content="Previous" Height="23.5" Width="100" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        <Button x:Name="Control_Restore_Btn_Next" Content="Next" Height="23.5" Width="100" Margin="10,0,0,0" HorizontalAlignment="Center" VerticalAlignment="Center" IsEnabled="False"/>
+                    </StackPanel>
+                </StackPanel>
+                <!--#endregion Restore-->
                 <!--#region Summary-->
                 <StackPanel x:Name="Control_Summary_Stp" HorizontalAlignment="Left" Visibility="Collapsed">
-                    <StackPanel Height="320">
+                    <StackPanel Height="400">
                             <TextBlock x:Name="Control_Summary_Tbl_Header1" TextWrapping="Wrap" FontSize="16" FontFamily="Segoe UI"  HorizontalAlignment="Left" Margin="0,0,0,10" />
                             <TextBox x:Name="Control_Summary_Tbx_Content1" TextWrapping="Wrap" FontSize="14" FontFamily="Segoe UI" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Foreground="#A0A0A0" HorizontalAlignment="Left" Margin="0,0,0,10" Padding="5" Width="550" IsReadOnly="True" Visibility="Collapsed"  AutomationProperties.LabeledBy="{Binding ElementName=Control_Summary_Tbl_Header1}" />
                         <StackPanel Orientation="Horizontal">
@@ -1771,8 +1842,17 @@ Function F_Initialize {
             $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Mode_Title
             $syncHash.Control_Mode_Tbl_LeftTitle.Text = $Text_Install.Mode_LeftTitle
             $syncHash.Control_Mode_Tbl_LeftContent.Text = $Text_Install.Mode_LeftContent
+
+            # Show Reboot and recover options
+            $syncHash.Control_Mode_Btn_TopRight.VerticalAlignment = "Top"
+            $syncHash.Control_Mode_Btn_BottomRight.Visibility = "Visible"
+            $syncHash.Control_Mode_Tbl_BottomRightTitle.Text = $Text_Install.Mode_BottomRightTitle
+            $syncHash.Control_Mode_Tbl_BottomRightContent.Text = $Text_Install.Mode_BottomRightContent
         }
         else {
+            $syncHash.Control_Mode_Btn_TopRight.VerticalAlignment = "Stretch"
+            $syncHash.Control_Mode_Btn_BottomRight.Visibility = "Collapsed"
+
             # Import module to check current deployment status
             Import-Module "C:\CloudDeployment\ECEngine\EnterpriseCloudEngine.psd1" -Force -Verbose:$false
             $actionProgress = Get-ActionProgress -ActionType Deployment
@@ -1782,6 +1862,12 @@ Function F_Initialize {
                 $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Mode_Title
                 $syncHash.Control_Mode_Tbl_LeftTitle.Text = $Text_Install.Mode_LeftTitle
                 $syncHash.Control_Mode_Tbl_LeftContent.Text = $Text_Install.Mode_LeftContent
+
+                # Show Reboot and recover options
+                $syncHash.Control_Mode_Btn_TopRight.VerticalAlignment = "Top"
+                $syncHash.Control_Mode_Btn_BottomRight.Visibility = "Visible"
+                $syncHash.Control_Mode_Tbl_BottomRightTitle.Text = $Text_Install.Mode_BottomRightTitle
+                $syncHash.Control_Mode_Tbl_BottomRightContent.Text = $Text_Install.Mode_BottomRightContent
             }
             elseif($actionProgress.Attribute("Status").Value -eq 'Success') {
                 # Deployment completed
@@ -1791,7 +1877,7 @@ Function F_Initialize {
                 $syncHash.Control_Mode_Tbl_LeftContent.Text = $Text_Completed.Mode_LeftContent
             }
             # Deployment in progress or stopped
-            else{
+            else {
                 # Not deployed with deployment UI
                 if(!(test-path "C:\CloudDeployment\Rerun\config.xml")) {
                     New-Item C:\CloudDeployment\Rerun -type directory -Force
@@ -1824,8 +1910,8 @@ Function F_Initialize {
 
         # Reboot options
         F_Reboot_Options
-        $syncHash.Control_Mode_Tbl_RightTitle.Text = $Text_Install.Mode_RightTitle
-        $syncHash.Control_Mode_Tbl_RightContent.Text = $Text_Install.Mode_RightContent
+        $syncHash.Control_Mode_Tbl_TopRightTitle.Text = $Text_Install.Mode_TopRightTitle
+        $syncHash.Control_Mode_Tbl_TopRightContent.Text = $Text_Install.Mode_TopRightContent
     }
     # Booted from vhdx, but not CloudBuilder.vhdx
     elseif ((get-disk | Where-Object {$_.isboot -eq $true}).Model -match 'Virtual Disk') {
@@ -1848,8 +1934,8 @@ Function F_Initialize {
         $syncHash.Control_Header_Tbl_Title.Text = $Text_SafeOS.Mode_Title
         $syncHash.Control_Mode_Tbl_LeftTitle.Text = $Text_SafeOS.Mode_LeftTitle
         $syncHash.Control_Mode_Tbl_LeftContent.Text = $Text_SafeOS.Mode_LeftContent
-        $syncHash.Control_Mode_Tbl_RightTitle.Text = $Text_SafeOS.Mode_RightTitle
-        $syncHash.Control_Mode_Tbl_RightContent.Text = $Text_SafeOS.Mode_RightContent
+        $syncHash.Control_Mode_Tbl_TopRightTitle.Text = $Text_SafeOS.Mode_TopRightTitle
+        $syncHash.Control_Mode_Tbl_TopRightContent.Text = $Text_SafeOS.Mode_TopRightContent
     }
 
 Write-Host "." -ForegroundColor Cyan
@@ -1969,7 +2055,13 @@ Function F_Verify_LocalAdminCreds {
 }
 
 Function F_VerifyFields_Creds {
-    if (
+    if ($Script:Restore -and
+        ($syncHash.Control_Creds_Pwb_LocalPassword.Password.Length -gt 0) -and
+        ($syncHash.Control_Creds_Tbx_AADTenant.Text -and ($syncHash.Control_Creds_Tbx_AADTenant.BorderBrush.color -ne "#FFFF0000")))
+    {
+        $syncHash.Control_Creds_Btn_Next.IsEnabled = $true
+    }
+    elseif (
         ($syncHash.Control_Creds_Cbx_Idp.SelectedItem -eq 'ADFS' -and
         ($syncHash.Control_Creds_Pwb_LocalPassword.Password.Length -gt 0)) -or
         (
@@ -1982,6 +2074,22 @@ Function F_VerifyFields_Creds {
     }
     Else {
         $syncHash.Control_Creds_Btn_Next.IsEnabled = $false
+    }
+}
+
+Function F_VerifyFields_Restore {
+    if ($syncHash.Control_Restore_Tbx_BackupStorePath.Text -and
+        $syncHash.Control_Restore_Tbx_BackupStoreUserName -and
+        ($syncHash.Control_Restore_Pwb_BackupStorePassword.Password.Length -gt 0) -and
+        $syncHash.Control_Restore_Tbx_BackupEncryptionKey.Text -and
+        $syncHash.Control_Restore_Tbx_BackupID.Text -and
+        ($syncHash.Control_Restore_Pwb_ExternalCertPassword.Password.Length -gt 0))
+    {
+        $syncHash.Control_Restore_Btn_Next.IsEnabled = $true
+    }
+    else
+    {
+        $syncHash.Control_Restore_Btn_Next.IsEnabled = $false
     }
 }
 
@@ -2097,14 +2205,31 @@ Function F_Summary {
 
         $InstallScript += '$adminpass = ConvertTo-SecureString ' + "'" + ($syncHash.Control_Creds_Pwb_LocalPassword.PasswordChar.ToString() * $syncHash.Control_Creds_Pwb_LocalPassword.Password.Length) +"'" + '-AsPlainText -Force'
         $InstallScript += "`r`n"
+
+        if ($Script:Restore)
+        {
+            $InstallScript += '$backupEncryptionKey = ConvertTo-SecureString ' + "'" + $syncHash.Control_Restore_Tbx_BackupEncryptionKey.Text + "'" + ' -AsPlainText -Force'
+            $InstallScript += "`r`n"
+
+            $InstallScript += '$backupSharePassword = ConvertTo-SecureString ' + "'" + ($syncHash.Control_Restore_Pwb_BackupStorePassword.PasswordChar.ToString() * $syncHash.Control_Restore_Pwb_BackupStorePassword.Password.Length) + "'" + ' -AsPlainText -Force'
+            $InstallScript += "`r`n"
+
+            $InstallScript += '$backupShareCred = New-Object System.Management.Automation.PSCredential(' + "'" + $syncHash.Control_Restore_Tbx_BackupStoreUserName.Text + "'" + ', $backupSharePassword)'
+            $InstallScript += "`r`n"
+
+            $InstallScript += '$externalCertPassword = ConvertTo-SecureString ' + "'" + $syncHash.Control_Restore_Pwb_ExternalCertPassword.PasswordChar.ToString() * $syncHash.Control_Restore_Pwb_ExternalCertPassword.Password.Length + "'" + ' -AsPlainText -Force'
+            $InstallScript += "`r`n"
+        }
+
         $InstallScript += 'cd C:\CloudDeployment\Setup'
         $InstallScript += "`r`n"
         $InstallScript += '.\InstallAzureStackPOC.ps1 -AdminPassword $adminpass'
 
         # Azure Cloud, Azure China Cloud, Azure US Government Cloud or ADFS
-        If ($synchash.Control_Creds_Cbx_Idp.SelectedItem -eq 'Azure Cloud') {
-                $InstallScript += " -InfraAzureDirectoryTenantName "
-                $InstallScript += $synchash.Control_Creds_Tbx_AADTenant.Text                
+        If (($synchash.Control_Creds_Cbx_Idp.SelectedItem -eq 'Azure Cloud' -or $Script:Restore) -and
+            ![string]::IsNullOrEmpty($synchash.Control_Creds_Tbx_AADTenant.Text)) {
+            $InstallScript += " -InfraAzureDirectoryTenantName "
+            $InstallScript += $synchash.Control_Creds_Tbx_AADTenant.Text
         }
         ElseIf ($synchash.Control_Creds_Cbx_Idp.SelectedItem -eq 'Azure China Cloud') {
                 $InstallScript += " -InfraAzureDirectoryTenantName "
@@ -2128,6 +2253,22 @@ Function F_Summary {
         If ($synchash.Control_NetConfig_Tbx_TimeServer.Text.Length -gt 0) {
             $InstallScript += " -TimeServer "
             $InstallScript += $synchash.Control_NetConfig_Tbx_TimeServer.Text
+        }
+
+        # Restore deployment parameters
+        if ($Script:Restore)
+        {
+            $InstallScript += " -BackupStorePath "
+            $InstallScript += $syncHash.Control_Restore_Tbx_BackupStorePath.Text
+
+            $InstallScript += ' -BackupStoreCredential $backupShareCred'
+
+            $InstallScript += ' -BackupEncryptionKeyBase64 $backupEncryptionKey'
+
+            $InstallScript += " -BackupId "
+            $InstallScript += $syncHash.Control_Restore_Tbx_BackupID.Text
+
+            $InstallScript += ' -ExternalCertPassword $externalCertPassword'
         }
 
         $syncHash.Control_Summary_Tbx_Content1.Text = $InstallScript
@@ -2172,12 +2313,22 @@ Function F_Install {
     Write-Host "Defining installation parameters" -ForegroundColor Cyan 
            
     '$adminpass = ConvertTo-SecureString ' + "'" + $syncHash.Control_Creds_Pwb_LocalPassword.Password + "'" + ' -AsPlainText -Force' | Add-Content $filepath
+
+    if ($Script:Restore)
+    {
+        '$backupEncryptionKey = ConvertTo-SecureString ' + "'" + $syncHash.Control_Restore_Tbx_BackupEncryptionKey.Text + "'" + ' -AsPlainText -Force' | Add-Content $filepath
+        '$backupSharePassword = ConvertTo-SecureString ' + "'" + $syncHash.Control_Restore_Pwb_BackupStorePassword.Password + "'" + ' -AsPlainText -Force' | Add-Content $filepath
+        '$backupShareCred = New-Object System.Management.Automation.PSCredential(' + "'" + $syncHash.Control_Restore_Tbx_BackupStoreUserName.Text + "'" + ', $backupSharePassword)' | Add-Content $filepath
+        '$externalCertPassword = ConvertTo-SecureString ' + "'" + $syncHash.Control_Restore_Pwb_ExternalCertPassword.Password + "'" + ' -AsPlainText -Force' | Add-Content $filepath
+    }
+
     "cd C:\CloudDeployment\Setup" |  Add-Content $filepath
     ".\InstallAzureStackPOC.ps1" |  Add-Content $filepath -NoNewline
     ' -AdminPassword $adminpass' |  Add-Content $filepath -NoNewline
 
     # Azure Cloud, Azure China Cloud, Azure US Government Cloud or ADFS
-    If ($synchash.Control_Creds_Cbx_Idp.SelectedItem -eq 'Azure Cloud') {
+    If (($synchash.Control_Creds_Cbx_Idp.SelectedItem -eq 'Azure Cloud' -or $Script:Restore) -and
+        ![string]::IsNullOrEmpty($synchash.Control_Creds_Tbx_AADTenant.Text)) {
         ' -InfraAzureDirectoryTenantName "' + $synchash.Control_Creds_Tbx_AADTenant.Text + '"' |  Add-Content $filepath -NoNewline
     }
     ElseIf ($synchash.Control_Creds_Cbx_Idp.SelectedItem -eq 'Azure US Government Cloud') {
@@ -2202,7 +2353,15 @@ Function F_Install {
     Else {
         ' -TimeServer "' + 'pool.ntp.org' + '"' |  Add-Content $filepath -NoNewline
     }
- 
+
+    if ($Script:Restore)
+    {
+        ' -BackupStorePath ' + '"' + $syncHash.Control_Restore_Tbx_BackupStorePath.Text + '"' | Add-Content $filepath -NoNewline
+        ' -BackupStoreCredential $backupShareCred' | Add-Content $filepath -NoNewline
+        ' -BackupEncryptionKeyBase64 $backupEncryptionKey' | Add-Content $filepath -NoNewline
+        ' -BackupId ' + '"' + $syncHash.Control_Restore_Tbx_BackupID.Text + '"' | Add-Content $filepath -NoNewline
+        ' -ExternalCertPassword $externalCertPassword' | Add-Content $filepath -NoNewline
+    }
     #endregion
 
     #region Rerun Count
@@ -2274,14 +2433,31 @@ $syncHash.Control_Mode_Btn_Left.Add_Click({
     }
 })
 
-$syncHash.Control_Mode_Btn_Right.Add_Click({
+# This button is only supposed to show up when $Script:Initialized -eq "CloudBuilder_Install"
+$syncHash.Control_Mode_Btn_BottomRight.Add_Click({
+    $syncHash.Control_Mode_Stp.Visibility = "Collapsed"
+
+    $syncHash.Control_Creds_Stp.Visibility = "Visible"
+    $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Credentials_Title
+
+    $syncHash.Control_Creds_Cbx_Idp.AddChild("(Imported from backup data)")
+    $syncHash.Control_Creds_Cbx_Idp.SelectedItem = "(Imported from backup data)"
+    $syncHash.Control_Creds_Cbx_Idp.FontStyle = "Italic"
+    $syncHash.Control_Creds_Cbx_Idp.IsEnabled = $false
+
+    $syncHash.Control_Creds_Tbx_AADTenant.IsEnabled = $true
+    $Script:Restore = $true
+})
+
+$syncHash.Control_Mode_Btn_TopRight.Add_Click({
     if ($Script:Initialized -eq "SafeOS") {
-        Start-Process $Text_SafeOS.Mode_RightLink
+        Start-Process $Text_SafeOS.Mode_TopRightLink
     }
     else {
         $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Reboot_Title
         $syncHash.Control_Mode_Stp.Visibility = "Collapsed"
         $syncHash.Control_Reboot_Stp.Visibility = "Visible"
+        $syncHash.Control_Creds_Cbx_Idp.IsEnabled = $true
         F_Reboot_Options
     }
 })
@@ -2457,6 +2633,16 @@ $syncHash.Control_Creds_Btn_Previous.Add_Click({
     $syncHash.Control_Creds_Stp.Visibility = "Collapsed"
     $syncHash.Control_Mode_Stp.Visibility = "Visible"
     $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Mode_Title
+
+    $Script:Restore = $false
+    $syncHash.Control_Creds_Cbx_Idp.Items.Remove("(Imported from backup data)")
+    $syncHash.Control_Creds_Cbx_Idp.FontStyle = "Normal"
+    $syncHash.Control_Creds_Cbx_Idp.IsEnabled = $true
+
+    $syncHash.Control_Creds_Tbx_AADTenant.Text.Clear()
+    $syncHash.Control_Creds_Tbx_AADTenant.IsEnabled = $false
+
+    $syncHash.Control_Creds_Pwb_LocalPassword.Clear()
 })
 
 $syncHash.Control_Creds_Btn_Next.Add_Click({
@@ -2632,6 +2818,10 @@ $syncHash.Control_Job_Btn_Next.Add_Click({
         $syncHash.Control_Summary_Btn_Next.Content = "Reboot now"
         F_Summary
     }
+    elseif ($Script:Restore) {
+        $syncHash.Control_Restore_Stp.Visibility = "Visible"
+        $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Restore_Title
+    }
     else {
         $syncHash.Control_Summary_Stp.Visibility = "Visible"
         $SyncHash.Control_Summary_Btn_Next.Content = "Deploy"
@@ -2653,6 +2843,52 @@ $syncHash.Control_Job_Btn_Netbxnda.Add_Click({
 })
 #endregion Events Job
 
+#region Events Restore
+$syncHash.Control_Restore_Btn_Previous.Add_Click({
+    $syncHash.Control_Restore_Stp.Visibility = "Collapsed"
+    $syncHash.Control_Job_Stp.Visibility = "Visible"
+    $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Job_Title
+})
+
+$syncHash.Control_Restore_Btn_Next.Add_Click({
+    $syncHash.Control_Restore_Stp.Visibility = "Collapsed"
+    $syncHash.Control_Summary_Stp.Visibility = "Visible"
+    $SyncHash.Control_Summary_Btn_Next.Content = "Deploy"
+    $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Summary_Title
+    F_Summary
+})
+
+$syncHash.Control_Restore_Tbx_BackupStorePath.Add_TextChanged({
+    F_Regex -field 'Control_Restore_Tbx_BackupStorePath'
+    F_VerifyFields_Restore
+})
+
+$syncHash.Control_Restore_Tbx_BackupStoreUserName.Add_TextChanged({
+    F_Regex -field 'Control_Restore_Tbx_BackupStoreUserName'
+    F_VerifyFields_Restore
+})
+
+$syncHash.Control_Restore_Pwb_BackupStorePassword.Add_PasswordChanged({
+    F_Regex -field 'Control_Restore_Pwb_BackupStorePassword'
+    F_VerifyFields_Restore
+})
+
+$syncHash.Control_Restore_Tbx_BackupEncryptionKey.Add_TextChanged({
+    F_Regex -field 'Control_Restore_Tbx_BackupEncryptionKey'
+    F_VerifyFields_Restore
+})
+
+$syncHash.Control_Restore_Tbx_BackupID.Add_TextChanged({
+    F_Regex -field 'Control_Restore_Tbx_BackupID'
+    F_VerifyFields_Restore
+})
+
+$syncHash.Control_Restore_Pwb_ExternalCertPassword.Add_PasswordChanged({
+    F_Regex -field 'Control_Restore_Pwb_ExternalCertPassword'
+    F_VerifyFields_Restore
+})
+#endregion Events Restore
+
 #region Events Summary
 $syncHash.Control_Summary_Btn_Previous.Add_Click({
     $syncHash.Control_Summary_Stp.Visibility = "Collapsed"
@@ -2660,8 +2896,16 @@ $syncHash.Control_Summary_Btn_Previous.Add_Click({
         $Form.Close()
     }
     ElseIf ($Script:Initialized -eq "CloudBuilder_Install") {
-        $syncHash.Control_NetConfig_Stp.Visibility = "Visible"
-        $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.NetConfig_Title
+        if ($Script:Restore)
+        {
+            $syncHash.Control_Restore_Stp.Visibility = "Visible"
+            $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.Restore_Title
+        }
+        else
+        {
+            $syncHash.Control_NetConfig_Stp.Visibility = "Visible"
+            $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.NetConfig_Title
+        }
     }
     ElseIf ($Script:Initialized -eq "CloudBuilder_Rerun") {
         $syncHash.Control_Mode_Stp.Visibility = "Visible"

--- a/Deployment/asdk-installer.ps1
+++ b/Deployment/asdk-installer.ps1
@@ -29,7 +29,7 @@ The Azure Stack Development Kit installer UI script is based on PowerShell and t
 
 #region Text
 $Text_Generic = @{}
-$Text_Generic.Version = "1.0.12"
+$Text_Generic.Version = "1.0.13"
 $Text_Generic.Password_NotMatch = "Passwords do not match"
 $Text_Generic.Regex_Fqdn = "<yourtenant.onmicrosoft.com> can only contain A-Z, a-z, 0-9, dots and a hyphen"
 $Text_Generic.Regex_Computername = "Computername must be 15 characters or less and can only contain A-Z, a-z, 0-9 and a hyphen"
@@ -65,7 +65,7 @@ $Text_Install.Mode_RightContent = "Select the Operating System to override the d
 $Text_Install.Reboot_Title = "Reboot"
 $Text_Install.NetInterface_Title = "Select Network Interface for the Azure Stack host"
 $Text_Install.NetInterface_Warning = "Only one adapter can be used for the Azure Stack Development Kit host. Select the adapter used for the deployment. All other adapters will be disabled by the installer. Ensure you have network connectivity to the selected network adapter before proceeding."
-$Text_Install.NetConfig_Title = "Network Configuration for BGPNAT01"
+$Text_Install.NetConfig_Title = "Network Configuration"
 $Text_Install.Credentials_Title = "Specify Identity Provider and Credentials"
 $Text_Install.Summary_Title = "Summary"
 $Text_Install.Summary_Content = "The following script will be used for deploying the Development Kit"
@@ -1189,17 +1189,11 @@ $Xaml = @'
                 <!--#region NetConfig-->
                 <StackPanel x:Name="Control_NetConfig_Stp" HorizontalAlignment="Left" Visibility="Collapsed">
                     <StackPanel Height="320">
-                        <RadioButton x:Name="Control_NetConfig_Rbt_DHCP" GroupName="NetworkConfig" VerticalContentAlignment="Center" Cursor="Hand" Margin="0,0,0,5" IsChecked="True"  >
-                            <TextBlock FontSize="14" FontFamily="Segoe UI"  Text="DHCP" Width="100" HorizontalAlignment="Left" Padding="5,0,0,0"/>
-                        </RadioButton>
-                        <RadioButton x:Name="Control_NetConfig_Rbt_Static" GroupName="NetworkConfig" VerticalContentAlignment="Center" Cursor="Hand" Margin="0,0,0,10"  >
-                            <TextBlock FontSize="14" FontFamily="Segoe UI"  Text="Static" Width="100" HorizontalAlignment="Left" Padding="5,0,0,0"/>
-                        </RadioButton>
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10" x:Name="Control_NetConfig_Stp_IpAddress">
                             <TextBlock x:Name="Control_NetConfig_Tbl_IpAddress" FontSize="14" FontFamily="Segoe UI"  Text="Ip Address:" Width="120" HorizontalAlignment="Left"/>
                             <TextBox x:Name="Control_NetConfig_Tbx_IpAddress" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Width="430" IsEnabled="False" AutomationProperties.LabeledBy="{Binding ElementName=Control_NetConfig_Tbl_IpAddress}"/>
                         </StackPanel>
-                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
+                        <StackPanel Orientation="Horizontal" Margin="0,0,0,10" x:Name="Control_NetConfig_Stp_Gateway">
                             <TextBlock x:Name="Control_NetConfig_Tbl_Gateway" FontSize="14" FontFamily="Segoe UI"  Text="Gateway:" Width="120" HorizontalAlignment="Left"/>
                             <TextBox x:Name="Control_NetConfig_Tbx_Gateway" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}"  Width="430" IsEnabled="False" AutomationProperties.LabeledBy="{Binding ElementName=Control_NetConfig_Tbl_Gateway}"/>
                         </StackPanel>
@@ -1213,10 +1207,6 @@ $Xaml = @'
                         </StackPanel>
                         <StackPanel x:Name="Control_NetConfig_Stp_Optional">
                             <TextBlock FontSize="16" FontFamily="Segoe UI"  Text="Optional Configuration" Margin="0,0,0,10"/>
-                            <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
-                                <TextBlock x:Name="Control_NetConfig_Tbl_VlanID" FontSize="14" FontFamily="Segoe UI"  Text="VLAN ID:" Width="120" HorizontalAlignment="Left"/>
-                                <TextBox x:Name="Control_NetConfig_Tbx_VlanID" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Width="430" AutomationProperties.LabeledBy="{Binding ElementName=Control_NetConfig_Tbl_VlanID}" />
-                            </StackPanel>
                             <StackPanel Orientation="Horizontal" Margin="0,0,0,10">
                                 <TextBlock x:Name="Control_NetConfig_Tbl_DnsForwarder" FontSize="14" FontFamily="Segoe UI"  Text="DNS Forwarder IP:" Width="120" HorizontalAlignment="Left"/>
                                 <TextBox x:Name="Control_NetConfig_Tbx_DnsForwarder" BorderBrush="{DynamicResource {x:Static SystemColors.ActiveBorderBrushKey}}" Width="430" AutomationProperties.LabeledBy="{Binding ElementName=Control_NetConfig_Tbl_DnsForwarder}"/>
@@ -2007,19 +1997,12 @@ Function F_VerifyFields_NetConfig {
         Else {$syncHash.Control_NetConfig_Btn_Next.IsEnabled = $false}
     }
     else {
-        if (
-            (
-                $syncHash.Control_NetConfig_Rbt_DHCP.IsChecked -eq $true -and
-                ($syncHash.Control_NetConfig_Tbx_TimeServer.Text -and ($syncHash.Control_NetConfig_Tbx_TimeServer.BorderBrush.color -ne "#FFFF0000"))
-            ) -or
-            (
-                $syncHash.Control_NetConfig_Rbt_Static.IsChecked -eq $true -and
-                ($syncHash.Control_NetConfig_Tbx_IpAddress.Text -and ($syncHash.Control_NetConfig_Tbx_IpAddress.BorderBrush.color -ne "#FFFF0000")) -and
-                ($syncHash.Control_NetConfig_Tbx_Gateway.Text -and ($syncHash.Control_NetConfig_Tbx_Gateway.BorderBrush.color -ne "#FFFF0000")) -and
-                ($syncHash.Control_NetConfig_Tbx_TimeServer.Text -and ($syncHash.Control_NetConfig_Tbx_TimeServer.BorderBrush.color -ne "#FFFF0000"))
-            )
-            ) {$syncHash.Control_NetConfig_Btn_Next.IsEnabled = $true}
-        Else {$syncHash.Control_NetConfig_Btn_Next.IsEnabled = $false}
+        if (($syncHash.Control_NetConfig_Tbx_TimeServer.Text -and ($syncHash.Control_NetConfig_Tbx_TimeServer.BorderBrush.color -ne "#FFFF0000"))) {
+            $syncHash.Control_NetConfig_Btn_Next.IsEnabled = $true
+        }
+        Else {
+            $syncHash.Control_NetConfig_Btn_Next.IsEnabled = $false
+        }
     }
 }
 
@@ -2137,21 +2120,6 @@ Function F_Summary {
                 $InstallScript += " -UseADFS"
         }
 
-        If ($synchash.Control_NetConfig_Rbt_Static.IsChecked) {
-                $NetworkID = F_GetNetworkID
-                $InstallScript += " -NatIPv4Subnet "
-                $InstallScript += $NetworkID
-                $InstallScript += " -NatIPv4Address "
-                $InstallScript += $synchash.Control_NetConfig_Tbx_IpAddress.Text.Split("/")[0]
-                $InstallScript += " -NatIPv4DefaultGateway "
-                $InstallScript += $synchash.Control_NetConfig_Tbx_Gateway.Text
-        }
-
-        If ($synchash.Control_NetConfig_Tbx_VlanID.Text.Length -gt 0) {
-                $InstallScript += " -PublicVlanId "
-                $InstallScript += $synchash.Control_NetConfig_Tbx_VlanID.Text
-        }
-
         If ($synchash.Control_NetConfig_Tbx_DnsForwarder.Text.Length -gt 0) {
                 $InstallScript += " -DNSForwarder "
                 $InstallScript += $synchash.Control_NetConfig_Tbx_DnsForwarder.Text
@@ -2222,17 +2190,6 @@ Function F_Install {
     }
     ElseIf ($synchash.Control_Creds_Cbx_Idp.SelectedItem -eq 'ADFS') {
         ' -UseADFS' |  Add-Content $filepath -NoNewline
-    }
-
-    If ($synchash.Control_NetConfig_Rbt_Static.IsChecked) {
-        $NetworkID = F_GetNetworkID
-        ' -NatIPv4Subnet "' + $NetworkID + '"' |  Add-Content $filepath -NoNewline
-        ' -NatIPv4Address "' + $synchash.Control_NetConfig_Tbx_IpAddress.Text.Split("/")[0] + '"' |  Add-Content $filepath -NoNewline
-        ' -NatIPv4DefaultGateway "' + $synchash.Control_NetConfig_Tbx_Gateway.Text + '"' |  Add-Content $filepath -NoNewline
-    }
-
-    If ($synchash.Control_NetConfig_Tbx_VlanID.Text.Length -gt 0) {
-        ' -PublicVlanId "' + $synchash.Control_NetConfig_Tbx_VlanID.Text + '"' |  Add-Content $filepath -NoNewline
     }
 
     If ($synchash.Control_NetConfig_Tbx_DnsForwarder.Text.Length -gt 0) {
@@ -2567,8 +2524,6 @@ $syncHash.Control_NetInterface_Btn_Next.Add_Click({
     If ($Script:Initialized -eq "SafeOS") {
         $syncHash.Control_NetConfig_Stp.Visibility = "Visible"
         $syncHash.Control_Header_Tbl_Title.Text = $Text_SafeOS.NetConfig_Title
-        $SyncHash.Control_NetConfig_Rbt_Static.Visibility="Collapsed"
-        $SyncHash.Control_NetConfig_Rbt_DHCP.Visibility="Collapsed"
         $SyncHash.Control_NetConfig_Stp_Optional.Visibility="Collapsed"
         F_CopyNicProperties
     }
@@ -2576,6 +2531,8 @@ $syncHash.Control_NetInterface_Btn_Next.Add_Click({
         $syncHash.Control_NetConfig_Stp.Visibility = "Visible"
         $syncHash.Control_Header_Tbl_Title.Text = $Text_Install.NetConfig_Title
         $syncHash.Control_NetConfig_Stp_DNS.Visibility="Collapsed"
+        $syncHash.Control_NetConfig_Stp_IpAddress.Visibility="Collapsed"
+        $syncHash.Control_NetConfig_Stp_Gateway.Visibility="Collapsed"
     }
 })
 
@@ -2619,28 +2576,6 @@ $syncHash.Control_NetConfig_Btn_Next.Add_Click({
         $Runspace_Jobs.Runspace = $Runspace_Jobs_Properties
         $Runspace_Jobs_Output = $Runspace_Jobs.BeginInvoke()
     }
-})
-
-$syncHash.Control_NetConfig_Rbt_DHCP.Add_Click({
-    $syncHash.Control_NetConfig_Tbx_IpAddress.IsEnabled = $false
-    $syncHash.Control_NetConfig_Tbx_IpAddress.Clear()
-    $syncHash.Control_NetConfig_Tbx_Gateway.IsEnabled = $false
-    $syncHash.Control_NetConfig_Tbx_Gateway.Clear()
-    $syncHash.Control_NetConfig_Tbx_DNS.IsEnabled = $false
-    $syncHash.Control_NetConfig_Tbx_DNS.Clear()
-    F_VerifyFields_NetConfig
-})
-
-$syncHash.Control_NetConfig_Rbt_Static.Add_Click({
-    $syncHash.Control_NetConfig_Tbx_IpAddress.IsEnabled = $true
-    $syncHash.Control_NetConfig_Tbx_Gateway.IsEnabled = $true
-    $syncHash.Control_NetConfig_Tbx_DNS.IsEnabled = $true
-
-    if ($script:Initialized -eq "SafeOS"){
-        F_CopyNicProperties
-    }
-
-    F_VerifyFields_NetConfig
 })
 
 $syncHash.Control_NetConfig_Tbx_IpAddress.Add_TextChanged({


### PR DESCRIPTION
Changes to the ASDK Installer UI to remove bgpnat parameters coinciding with the removal of bgpnat from ASDK in 1812 release.
This was tested by running the installer with the bgpnat less build to validate the deployment is completed for different settings including static/dhcp/dns forwarding settings.

Changes also include adding restore deployment support to the installer.

DO NOT MERGE until 1812 release