### PR TITLE
Add a option to reduce premium download threads number

### DIFF
--- a/Syndication/AzureStack.MarketplaceSyndication.psm1
+++ b/Syndication/AzureStack.MarketplaceSyndication.psm1
@@ -19,6 +19,9 @@ function Export-AzSOfflineMarketplaceItem {
         [ValidateNotNullorEmpty()]
         [String] $ResourceGroup = "azurestack",
 
+        [Parameter(Mandatory = $false, ParameterSetName = 'SyncOfflineAzsMarketplaceItem')]
+        [Switch] $ReduceDownloadThreads = $false,
+
         [Parameter(Mandatory = $true, ParameterSetName = 'SyncOfflineAzsMarketplaceItem')]
         [ValidateNotNullorEmpty()]
         [String] $Destination
@@ -82,7 +85,7 @@ function Export-AzSOfflineMarketplaceItem {
     }
 
     $Marketitems|Out-GridView -Title 'Azure Marketplace Items' -PassThru|foreach {
-        Get-Dependency -productid $_.id -resourceGroup $ResourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $AzureSubscriptionID -registration $Registration -token $token -destination $Destination
+        Get-Dependency -productid $_.id -resourceGroup $ResourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $AzureSubscriptionID -registration $Registration -token $token -destination $Destination -reduceDownloadThreads:$reduceDownloadThreads
     }
 }
 
@@ -107,7 +110,10 @@ function Get-Dependency {
         [Object] $token,
 
         [parameter(mandatory = $true)]
-        [String] $destination
+        [String] $destination,
+
+        [parameter(mandatory = $true)]
+        [Switch] $reduceDownloadThreads
     )
 
     $Headers = @{ 'authorization' = "Bearer $($Token.AccessToken)"}
@@ -118,7 +124,7 @@ function Get-Dependency {
     {
         foreach ($id in $downloadDetails.properties.dependentProducts)
         {
-            Get-Dependency -productid $id -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination
+            Get-Dependency -productid $id -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination -reduceDownloadThreads:$reduceDownloadThreads
         }
     }
 
@@ -134,7 +140,7 @@ function Get-Dependency {
     }
 
     Write-Host "`nDownloading product: $productid" -ForegroundColor DarkCyan
-    Download-Product -productid $productid -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination
+    Download-Product -productid $productid -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination -reduceDownloadThreads:$reduceDownloadThreads
 }
 
 function Download-Product {
@@ -158,7 +164,10 @@ function Download-Product {
         [Object] $token,
 
         [parameter(mandatory = $true)]
-        [String] $destination
+        [String] $destination,
+
+        [parameter(mandatory = $true)]
+        [Switch] $reduceDownloadThreads
     )
 
     # get name of azpkg
@@ -267,7 +276,7 @@ function Download-Product {
             If ($downloadConfirmation -eq 'Y') {
                 $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                 If ($checktool -eq $true){
-                    DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -PremiumDownload -MaxRetry 2
+                    DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                     "$productFolder\$azpkgName.azpkg"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 else{
@@ -275,7 +284,7 @@ function Download-Product {
                     return
                 }
             } else {
-                DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -MaxRetry 2
+                DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                 "$productFolder\$azpkgName.azpkg"|out-file "$productFolder\$azpkgName.txt" -Append
             }
         }
@@ -298,23 +307,23 @@ function Download-Product {
             $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
             If ($checktool -eq $true){
                 if ($icon.hero) {
-                    DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -PremiumDownload -MaxRetry 2
+                    DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                     "$iconsFolder\hero.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.large) {
-                    DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -PremiumDownload -MaxRetry 2
+                    DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                     "$iconsFolder\large.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.medium) {
-                    DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -PremiumDownload -MaxRetry 2
+                    DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                     "$iconsFolder\medium.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.small) {
-                    DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -PremiumDownload -MaxRetry 2
+                    DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                     "$iconsFolder\small.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.wide) {
-                    DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -PremiumDownload -MaxRetry 2
+                    DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                     "$iconsFolder\wide.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 Write-Verbose "icons has been downloaded" -verbose
@@ -325,23 +334,23 @@ function Download-Product {
             }
         } else {
             if ($icon.hero) {
-                DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                 "$iconsFolder\hero.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.large) {
-                DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                 "$iconsFolder\large.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.medium) {
-                DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                 "$iconsFolder\medium.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.small) {
-                DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                 "$iconsFolder\small.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.wide) {
-                DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                 "$iconsFolder\wide.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             Write-Verbose "icons has been downloaded" -verbose
@@ -364,14 +373,14 @@ function Download-Product {
                     If ($downloadConfirmation -eq 'Y') {
                         $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                         If ($checktool -eq $true){
-                            DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -PremiumDownload -MaxRetry 2
+                            DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                             "$productFolder\$vhdName.vhd"|out-file "$productFolder\$azpkgName.txt" -Append
                         } else {
                             Write-Verbose "Please install Azure Storage Tools AzCopy first,canceling" -verbose
                             return
                         }
                     } else {
-                        DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -MaxRetry 2
+                        DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                     }
                     Write-Verbose "$vhdName.vhd has been downloaded" -verbose
                     "$productFolder\$vhdName.vhd"|out-file "$productFolder\$azpkgName.txt" -Append
@@ -393,7 +402,7 @@ function Download-Product {
                     If ($downloadConfirmation -eq 'Y') {
                         $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                         If ($checktool -eq $true){
-                            DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -PremiumDownload -MaxRetry 2
+                            DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                             "$productFolder\$zipName.zip"|out-file "$productFolder\$azpkgName.txt" -Append
                             $productDetailsProperties['sourceBlob'].uri = "$zipName.zip"
                         } else {
@@ -401,7 +410,7 @@ function Download-Product {
                             return
                         }
                     } else {
-                        DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -MaxRetry 2
+                        DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                         "$productFolder\$zipName.zip"|out-file "$productFolder\$azpkgName.txt" -Append
                         $productDetailsProperties['sourceBlob'].uri = "$zipName.zip"
                     }
@@ -439,14 +448,14 @@ function Download-Product {
                         If ($downloadConfirmation -eq 'Y') {
                             $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                             If ($checktool -eq $true){
-                                DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -PremiumDownload -MaxRetry 2
+                                DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
                                 "$productFolder\$containerName"|out-file "$productFolder\$azpkgName.txt" -Append
                             } else {
                                 Write-Verbose "Please install Azure Storage Tools AzCopy first,canceling" -verbose
                                 return
                             }
                         } else {
-                            DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -MaxRetry 2
+                            DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
                             "$productFolder\$containerName"|out-file "$productFolder\$azpkgName.txt" -Append
                         }
                     }
@@ -480,6 +489,9 @@ function DownloadMarketplaceProduct {
         [Parameter(Mandatory = $true)]
         [String] $ProductName,
 
+        [parameter(mandatory = $true)]
+        [Switch] $reduceDownloadThreads,
+
         [Parameter(Mandatory = $false)]
         [Switch] $PremiumDownload,
 
@@ -503,7 +515,11 @@ function DownloadMarketplaceProduct {
     while (-not $completed) {
         try {
             if ($PremiumDownload) {
-                & 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe' /Source:$Source /Dest:$tmpDestination /Y
+                if ($reduceDownloadThreads) {
+                    & 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe' /Source:$Source /Dest:$tmpDestination /Y /NC:1
+                } else {
+                    & 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe' /Source:$Source /Dest:$tmpDestination /Y
+                }
             } else {
                 $wc = New-Object System.Net.WebClient
                 $wc.DownloadFile($Source, $tmpDestination)

--- a/Syndication/AzureStack.MarketplaceSyndication.psm1
+++ b/Syndication/AzureStack.MarketplaceSyndication.psm1
@@ -20,7 +20,8 @@ function Export-AzSOfflineMarketplaceItem {
         [String] $ResourceGroup = "azurestack",
 
         [Parameter(Mandatory = $false, ParameterSetName = 'SyncOfflineAzsMarketplaceItem')]
-        [Switch] $ReduceDownloadThreads = $false,
+        [ValidateRange(1, 128)]
+        [Int] $AzCopyDownloadThreads,
 
         [Parameter(Mandatory = $true, ParameterSetName = 'SyncOfflineAzsMarketplaceItem')]
         [ValidateNotNullorEmpty()]
@@ -73,7 +74,7 @@ function Export-AzSOfflineMarketplaceItem {
         }
         $displayType = $displayKind[$product.properties.productKind]
 
-		Write-output ([pscustomobject]@{
+        Write-output ([pscustomobject]@{
             Id          = $product.name.Split('/')[-1]
             Type        = $displayType
             Name        = $product.properties.displayName
@@ -85,7 +86,11 @@ function Export-AzSOfflineMarketplaceItem {
     }
 
     $Marketitems|Out-GridView -Title 'Azure Marketplace Items' -PassThru|foreach {
-        Get-Dependency -productid $_.id -resourceGroup $ResourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $AzureSubscriptionID -registration $Registration -token $token -destination $Destination -reduceDownloadThreads:$reduceDownloadThreads
+        if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+            Get-Dependency -productid $_.id -resourceGroup $ResourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $AzureSubscriptionID -registration $Registration -token $token -destination $Destination -AzCopyDownloadThreads $AzCopyDownloadThreads
+        } else {
+            Get-Dependency -productid $_.id -resourceGroup $ResourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $AzureSubscriptionID -registration $Registration -token $token -destination $Destination
+        }
     }
 }
 
@@ -112,8 +117,9 @@ function Get-Dependency {
         [parameter(mandatory = $true)]
         [String] $destination,
 
-        [parameter(mandatory = $true)]
-        [Switch] $reduceDownloadThreads
+        [parameter(mandatory = $false)]
+        [ValidateRange(1, 128)]
+        [Int] $azCopyDownloadThreads
     )
 
     $Headers = @{ 'authorization' = "Bearer $($Token.AccessToken)"}
@@ -124,7 +130,11 @@ function Get-Dependency {
     {
         foreach ($id in $downloadDetails.properties.dependentProducts)
         {
-            Get-Dependency -productid $id -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination -reduceDownloadThreads:$reduceDownloadThreads
+            if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                Get-Dependency -productid $id -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination -azCopyDownloadThreads $azCopyDownloadThreads
+            } else {
+                Get-Dependency -productid $id -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination
+            }
         }
     }
 
@@ -140,7 +150,11 @@ function Get-Dependency {
     }
 
     Write-Host "`nDownloading product: $productid" -ForegroundColor DarkCyan
-    Download-Product -productid $productid -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination -reduceDownloadThreads:$reduceDownloadThreads
+    if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+        Download-Product -productid $productid -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination -azCopyDownloadThreads $azCopyDownloadThreads
+    } else {
+        Download-Product -productid $productid -resourceGroup $resourceGroup -azureEnvironment $azureEnvironment -azureSubscriptionID $azureSubscriptionID -registration $registration -token $token -destination $destination
+    }
 }
 
 function Download-Product {
@@ -166,8 +180,9 @@ function Download-Product {
         [parameter(mandatory = $true)]
         [String] $destination,
 
-        [parameter(mandatory = $true)]
-        [Switch] $reduceDownloadThreads
+        [parameter(mandatory = $false)]
+        [ValidateRange(1, 128)]
+        [Int] $azCopyDownloadThreads
     )
 
     # get name of azpkg
@@ -276,7 +291,12 @@ function Download-Product {
             If ($downloadConfirmation -eq 'Y') {
                 $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                 If ($checktool -eq $true){
-                    DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                    if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                        DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                    } else {
+                        DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -PremiumDownload -MaxRetry 2
+                    }
+
                     "$productFolder\$azpkgName.azpkg"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 else{
@@ -284,7 +304,7 @@ function Download-Product {
                     return
                 }
             } else {
-                DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                DownloadMarketplaceProduct -Source $azpkgsource -Destination $azpkgdestination -ProductName "$azpkgName.azpkg" -MaxRetry 2
                 "$productFolder\$azpkgName.azpkg"|out-file "$productFolder\$azpkgName.txt" -Append
             }
         }
@@ -307,23 +327,43 @@ function Download-Product {
             $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
             If ($checktool -eq $true){
                 if ($icon.hero) {
-                    DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                    if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                        DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                    } else {
+                        DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -PremiumDownload -MaxRetry 2
+                    }
                     "$iconsFolder\hero.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.large) {
-                    DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                    if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                        DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                    } else {
+                        DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -PremiumDownload -MaxRetry 2
+                    }
                     "$iconsFolder\large.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.medium) {
-                    DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                    if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                        DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                    } else {
+                        DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -PremiumDownload -MaxRetry 2
+                    }
                     "$iconsFolder\medium.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.small) {
-                    DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                    if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                        DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                    } else {
+                        DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -PremiumDownload -MaxRetry 2
+                    }
                     "$iconsFolder\small.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 if ($icon.wide) {
-                    DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                    if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                        DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                    } else {
+                        DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -PremiumDownload -MaxRetry 2
+                    }
                     "$iconsFolder\wide.png"|out-file "$productFolder\$azpkgName.txt" -Append
                 }
                 Write-Verbose "icons has been downloaded" -verbose
@@ -334,23 +374,23 @@ function Download-Product {
             }
         } else {
             if ($icon.hero) {
-                DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.hero)" -Destination "$iconsFolder\hero.png" -ProductName "hero.png" -MaxRetry 2
                 "$iconsFolder\hero.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.large) {
-                DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.large)" -Destination "$iconsFolder\large.png" -ProductName "large.png" -MaxRetry 2
                 "$iconsFolder\large.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.medium) {
-                DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.medium)" -Destination "$iconsFolder\medium.png" -ProductName "medium.png" -MaxRetry 2
                 "$iconsFolder\medium.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.small) {
-                DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.small)" -Destination "$iconsFolder\small.png" -ProductName "small.png" -MaxRetry 2
                 "$iconsFolder\small.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             if ($icon.wide) {
-                DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                DownloadMarketplaceProduct -Source "$($icon.wide)" -Destination "$iconsFolder\wide.png" -ProductName "wide.png" -MaxRetry 2
                 "$iconsFolder\wide.png"|out-file "$productFolder\$azpkgName.txt" -Append
             }
             Write-Verbose "icons has been downloaded" -verbose
@@ -373,14 +413,18 @@ function Download-Product {
                     If ($downloadConfirmation -eq 'Y') {
                         $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                         If ($checktool -eq $true){
-                            DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                            if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                                DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                            } else {
+                                DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -PremiumDownload -MaxRetry 2
+                            }
                             "$productFolder\$vhdName.vhd"|out-file "$productFolder\$azpkgName.txt" -Append
                         } else {
                             Write-Verbose "Please install Azure Storage Tools AzCopy first,canceling" -verbose
                             return
                         }
                     } else {
-                        DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                        DownloadMarketplaceProduct -Source $vhdsource -Destination $vhddestination -ProductName "$vhdName.vhd" -MaxRetry 2
                     }
                     Write-Verbose "$vhdName.vhd has been downloaded" -verbose
                     "$productFolder\$vhdName.vhd"|out-file "$productFolder\$azpkgName.txt" -Append
@@ -402,7 +446,11 @@ function Download-Product {
                     If ($downloadConfirmation -eq 'Y') {
                         $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                         If ($checktool -eq $true){
-                            DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                            if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                                DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                            } else {
+                                DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -PremiumDownload -MaxRetry 2
+                            }
                             "$productFolder\$zipName.zip"|out-file "$productFolder\$azpkgName.txt" -Append
                             $productDetailsProperties['sourceBlob'].uri = "$zipName.zip"
                         } else {
@@ -410,7 +458,7 @@ function Download-Product {
                             return
                         }
                     } else {
-                        DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                        DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "$zipName.zip" -MaxRetry 2
                         "$productFolder\$zipName.zip"|out-file "$productFolder\$azpkgName.txt" -Append
                         $productDetailsProperties['sourceBlob'].uri = "$zipName.zip"
                     }
@@ -448,14 +496,18 @@ function Download-Product {
                         If ($downloadConfirmation -eq 'Y') {
                             $checktool= Test-Path "C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe"
                             If ($checktool -eq $true){
-                                DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -reduceDownloadThreads:$reduceDownloadThreads -PremiumDownload -MaxRetry 2
+                                if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                                    DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -azCopyDownloadThreads $azCopyDownloadThreads -PremiumDownload -MaxRetry 2
+                                } else {
+                                    DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -PremiumDownload -MaxRetry 2
+                                }
                                 "$productFolder\$containerName"|out-file "$productFolder\$azpkgName.txt" -Append
                             } else {
                                 Write-Verbose "Please install Azure Storage Tools AzCopy first,canceling" -verbose
                                 return
                             }
                         } else {
-                            DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -reduceDownloadThreads:$reduceDownloadThreads -MaxRetry 2
+                            DownloadMarketplaceProduct -Source $zipsource -Destination $zipdestination -ProductName "Container [$containerName]" -MaxRetry 2
                             "$productFolder\$containerName"|out-file "$productFolder\$azpkgName.txt" -Append
                         }
                     }
@@ -489,8 +541,9 @@ function DownloadMarketplaceProduct {
         [Parameter(Mandatory = $true)]
         [String] $ProductName,
 
-        [parameter(mandatory = $true)]
-        [Switch] $reduceDownloadThreads,
+        [parameter(mandatory = $false)]
+        [ValidateRange(1, 128)]
+        [Int] $azCopyDownloadThreads,
 
         [Parameter(Mandatory = $false)]
         [Switch] $PremiumDownload,
@@ -515,8 +568,8 @@ function DownloadMarketplaceProduct {
     while (-not $completed) {
         try {
             if ($PremiumDownload) {
-                if ($reduceDownloadThreads) {
-                    & 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe' /Source:$Source /Dest:$tmpDestination /Y /NC:1
+                if ($PSBoundParameters.ContainsKey('azCopyDownloadThreads')) {
+                    & 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe' /Source:$Source /Dest:$tmpDestination /Y /NC:$azCopyDownloadThreads
                 } else {
                     & 'C:\Program Files (x86)\Microsoft SDKs\Azure\AzCopy\AzCopy.exe' /Source:$Source /Dest:$tmpDestination /Y
                 }

--- a/Syndication/readme.md
+++ b/Syndication/readme.md
@@ -38,10 +38,10 @@ Get-AzureRmSubscription -SubscriptionID '<Your Azure Subscription GUID>' | Selec
 Import the module and start the export process for an Azure Marketplace item
 ```powershell
 Import-Module .\AzureStack.MarketplaceSyndication.psm1
-Export-AzSOfflineMarketplaceItem -destination "[Destination folder path]" -reduceDownloadThreads
+Export-AzSOfflineMarketplaceItem -destination "[Destination folder path]" -azCopyDownloadThreads "[AzCopy threads number]"
 ```
 
-Option -reduceDownloadThreads is optional. It should only be used when you have low-bandwidth network, and you are using premium download. It is to limit premium download threads number.
+Option -azCopyDownloadThreads is optional. It should only be used when you have low-bandwidth network, and you are using premium download. This option is to specifies the number of concurrent operations in AzCopy. If you are running across a low-bandwidth network, you can specify a lower number to avoid failure caused by resource competition.
 You can see more details at https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy#specify-the-number-of-concurrent-operations-to-start
 
 You will be prompted to select an Azure Marketplace item to download locally.

--- a/Syndication/readme.md
+++ b/Syndication/readme.md
@@ -38,8 +38,11 @@ Get-AzureRmSubscription -SubscriptionID '<Your Azure Subscription GUID>' | Selec
 Import the module and start the export process for an Azure Marketplace item
 ```powershell
 Import-Module .\AzureStack.MarketplaceSyndication.psm1
-Export-AzSOfflineMarketplaceItem -destination "[Destination folder path]"
+Export-AzSOfflineMarketplaceItem -destination "[Destination folder path]" -reduceDownloadThreads
 ```
+
+Option -reduceDownloadThreads is optional. It should only be used when you have low-bandwidth network, and you are using premium download. It is to limit premium download threads number.
+You can see more details at https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy#specify-the-number-of-concurrent-operations-to-start
 
 You will be prompted to select an Azure Marketplace item to download locally.
 ![](downloadselection.png)


### PR DESCRIPTION
In a slow network, or limited bandwidth network, AzCopy may timeout if use default concurrent operation number. This is to provide an option to prevent timeout error.