### PR TITLE
Fix for timeout during service principal creation

### DIFF
--- a/Registration/RegisterWithAzure.psm1
+++ b/Registration/RegisterWithAzure.psm1
@@ -1357,7 +1357,7 @@ function Activate-AzureStack{
     {
         try
         {
-            $activation = Invoke-Command -Session $session -ScriptBlock { New-AzureStackActivation -ActivationKey $using:ActivationKey }
+            $activation = Invoke-Command -Session $session -ScriptBlock { New-AzureStackActivation -ActivationKey $using:ActivationKey -TimeoutInSeconds 1800}
             break
         }
         catch

--- a/Registration/RegisterWithAzure.psm1
+++ b/Registration/RegisterWithAzure.psm1
@@ -1246,7 +1246,7 @@ Function New-ServicePrincipal{
         try
         {
             Log-Output "Creating Azure Active Directory service principal in tenant '$TenantId' Attempt $currentAttempt of $maxAttempt"
-            $servicePrincipal = Invoke-Command -Session $PSSession -ScriptBlock { New-AzureBridgeServicePrincipal -RefreshToken $using:RefreshToken -AzureEnvironment $using:AzureEnvironmentName -TenantId $using:TenantId }
+            $servicePrincipal = Invoke-Command -Session $PSSession -ScriptBlock { New-AzureBridgeServicePrincipal -RefreshToken $using:RefreshToken -AzureEnvironment $using:AzureEnvironmentName -TenantId $using:TenantId -TimeoutInSeconds 1800}
             Log-Output "Service principal created and Azure bridge configured. ObjectId: $($servicePrincipal.ObjectId)"
             return $servicePrincipal
         }


### PR DESCRIPTION
On slower ASDK hardware, some cmdlets can take longer to run, causing a timeout and failure to complete correctly. The default in the New-AzureBridgeServicePrincipal cmdlet is 300 seconds. This commit increases it to 1800.