### PR TITLE
scope token cache search to correct resource

### DIFF
--- a/Syndication/AzureStack.MarketplaceSyndication.psm1
+++ b/Syndication/AzureStack.MarketplaceSyndication.psm1
@@ -971,7 +971,7 @@ function Resolve-AccessToken {
         return $accessToken
     }
 
-    $cachedToken = $context.TokenCache.ReadItems() | Sort-Object -Property ExpiresOn -Descending | Select-Object -First 1
+    $cachedToken = $context.TokenCache.ReadItems() | Where-Object {$_.Resource -eq $context.Environment.ActiveDirectoryServiceEndpointResourceId} | Sort-Object -Property ExpiresOn -Descending | Select-Object -First 1
 
     if ($null -ne $cachedToken) {
         return $cachedToken.AccessToken


### PR DESCRIPTION
When retrieving an access token from the cache you should scope it to the resource you need to access. The Test-AzSOfflineMarketplaceItem failed fro me - as the token retrieved from the cache to use against  AzureStack was actually a token for public Azure. I've added a filter to only include tokens for the AzureStack instance you are working with.