### PR TITLE
Close the PSSession in New-AzsAdGraphServicePrincipal.

### DIFF
--- a/Identity/AzureStack.Identity.psm1
+++ b/Identity/AzureStack.Identity.psm1
@@ -59,12 +59,18 @@ function New-AzsAdGraphServicePrincipal {
     $computerName = $ERCSMachineName
     $cloudAdminCredential = $AdminCredential
     $domainAdminSession = New-PSSession -ComputerName $computerName  -Credential $cloudAdminCredential -configurationname privilegedendpoint  -Verbose
-    $GraphClientCertificate = New-SelfSignedCertificate -CertStoreLocation "cert:\CurrentUser\My" -Subject "CN=$ApplicationGroupName" -KeySpec KeyExchange
-    $graphRedirectUri = "https://localhost/".ToLowerInvariant()
-    $ApplicationName = $ApplicationGroupName
-    $application = Invoke-Command -Session $domainAdminSession -Verbose -ErrorAction Stop  `
-        -ScriptBlock { New-GraphApplication -Name $using:ApplicationName  -ClientRedirectUris $using:graphRedirectUri -ClientCertificates $using:GraphClientCertificate }
-    
+    try
+    {
+        $GraphClientCertificate = New-SelfSignedCertificate -CertStoreLocation "cert:\CurrentUser\My" -Subject "CN=$ApplicationGroupName" -KeySpec KeyExchange
+        $graphRedirectUri = "https://localhost/".ToLowerInvariant()
+        $ApplicationName = $ApplicationGroupName
+        $application = Invoke-Command -Session $domainAdminSession -Verbose -ErrorAction Stop  `
+            -ScriptBlock { New-GraphApplication -Name $using:ApplicationName  -ClientRedirectUris $using:graphRedirectUri -ClientCertificates $using:GraphClientCertificate }
+    }
+    finally
+    {
+        $domainAdminSession | Remove-PSSession
+    }
     return $application
 }
 


### PR DESCRIPTION
Close the PSSession in New-AzsAdGraphService principal, to avoid the ERCS VMs running out of memory when creating lots of service principals.