### PR TITLE
bug fix asdk-installer while deploying the asdk on azure VM

### DIFF
--- a/Deployment/asdk-installer.ps1
+++ b/Deployment/asdk-installer.ps1
@@ -2295,7 +2295,7 @@ Function F_Install {
     #endregion wrapper
 
     #region disable non selected NICs
-    if ($synchash.Control_NetInterface_Lvw_Nics.SelectedItem -and ($synchash.Control_NetInterface_Lvw_Nics.Items.count -gt 1)) {
+    if ($synchash.Control_NetInterface_Lvw_Nics.SelectedItem -and ($synchash.Control_NetInterface_Lvw_Nics.Items.count -ge 1)) {
         Write-Host "Disabling non selected NICs" -ForegroundColor Cyan
         $disable_nics = $synchash.Control_NetInterface_Lvw_Nics.Items | Where-Object {$_ -ne $synchash.Control_NetInterface_Lvw_Nics.SelectedItem}
         $disable_nics | ForEach-Object {


### PR DESCRIPTION
fix the installer bug while deploying the asdk on azure VM. 

While deploying ASDK on the azure VM, The following code could return 1.
```
$synchash.Control_NetInterface_Lvw_Nics.Items.count 
```
So the code execution will break.