### PR TITLE
Syntax error not visable in vscode, but visable in ISE

### DIFF
--- a/Deployment/asdk-prechecker.ps1
+++ b/Deployment/asdk-prechecker.ps1
@@ -19,7 +19,7 @@ The Azure Stack Development Kit Pre-Checker script is a PowerShell script publis
 https://github.com/Azure/AzureStack-Tools
 #>
 
-#requires –runasadministrator
+#requires -runasadministrator
 
 function CheckNestedVirtualization {
 
@@ -248,8 +248,8 @@ function CheckCPU {
 
     write-host -ForegroundColor yellow "["(date -format "HH:mm:ss")"]" "Checking processor information..."
 
-    $CPUCount = (Get-WmiObject -class win32_processor –computername localhost).count
-    $CoreCount =  ((Get-WmiObject -class win32_processor –computername localhost -Property "numberOfCores")[0].numberOfCores)*$CPUCount
+    $CPUCount = (Get-WmiObject -class win32_processor -computername localhost).count
+    $CoreCount =  ((Get-WmiObject -class win32_processor -computername localhost -Property "numberOfCores")[0].numberOfCores)*$CPUCount
     write-host -ForegroundColor gray "["(date -format "HH:mm:ss")"]" " -- Number of CPU sockets = $CPUCount"
     write-host -ForegroundColor gray "["(date -format "HH:mm:ss")"]" " -- Number of physical cores =  $CoreCount"
 


### PR DESCRIPTION
The '-' on line 22, and 2 more places, are actually ''â€“". Someone may have downloaded the script from a browser, or saved it with the wrong encoding. Vscode does not show this, but ISE does - open the original file (asdk-prechecker.ps1) in ISE (not in vscode), and check lines in the below images: 
![image](https://user-images.githubusercontent.com/46068634/133891269-d7d14509-f221-45e0-af82-6cbd28a61129.png)
![image](https://user-images.githubusercontent.com/46068634/133909758-9d1a5e83-e0f1-4312-bd11-cd857cb4b18c.png)

