### PR TITLE
Add example: Windows Server 2025 GEN1 platform image creation for Azure Stack Hub

### DIFF
--- a/Support/create-ws2025-image-from-azure/Example_WS2025-create-image-from-Azure.ps1
+++ b/Support/create-ws2025-image-from-azure/Example_WS2025-create-image-from-Azure.ps1
@@ -1,0 +1,312 @@
+
+<#
+.SYNOPSIS
+    Downloads a Windows Server 2025 Datacenter VHD from Azure Marketplace and imports it
+    into Azure Stack Hub as a platform image.
+
+.DESCRIPTION
+    DISCLAIMER: This script is provided as an EXAMPLE ONLY and is NOT a supported service
+    offering. It is provided under the MIT License on an "AS-IS" basis, without warranty
+    of any kind, express or implied. Use at your own risk.
+
+    This script performs the following steps:
+      1. Installs the required PowerShell modules (Az, AzureStack).
+      2. Logs into public Azure via Azure CLI and finds the latest WS2025 Gen1 image.
+      3. Creates a managed disk from that marketplace image, then exports the VHD using AzCopy.
+      4. Connects to Azure Stack Hub, uploads the VHD to a storage account.
+      5. Registers the VHD as a platform image in the Azure Stack Hub marketplace.
+
+.NOTES
+    Prerequisites:
+      - Azure CLI installed (see _Pre-req_Install_AzCLI.ps1)
+      - Run as Administrator
+      - Azure Stack Hub admin access
+      - Sufficient disk space for the VHD download (~30 GB for full disk, ~10 GB for small disk)
+
+    Adjust the parameters below to match your environment before running.
+
+.PARAMETER CleanAzModules
+    If specified, uninstalls every existing Az.*, Azs.* and Azure* PowerShell module on the
+    machine before installing the 2020-09-01-hybrid profile. WARNING: this affects every
+    PowerShell session on this workstation, not just this script. Off by default.
+
+.PARAMETER ClearAzCliAccount
+    If specified, runs 'az account clear' which removes ALL cached Azure CLI sessions on
+    this machine before logging in. Off by default.
+
+.PARAMETER AzureLocation
+    Azure (public cloud) region used to create the temporary managed disk. Default: eastus.
+#>
+[CmdletBinding()]
+param(
+    [switch]$CleanAzModules,
+    [switch]$ClearAzCliAccount,
+    [string]$AzureLocation = 'eastus'
+)
+
+#region ========================== PARAMETERS - EDIT THESE ==========================
+
+# --- Azure (public cloud) settings ---
+$AzureResourceGroup        = "ws2025-image-rg"          # Resource group in Azure to create the temp disk
+$AzureDiskName             = "WindowsServer-2025"        # Name for the temporary managed disk in Azure
+
+# --- Local download settings ---
+$VhdDownloadPath           = "C:\VHDs\WS2025-datacenter.vhd"  # Local path to save the downloaded VHD
+
+# --- Azure Stack Hub settings ---
+$EnvironmentName           = "AzureStackEnv"             # Name for the Az environment registration
+$AdminArmEndpoint          = "https://adminmanagement.<region>.<fqdn>"  # Azure Stack Hub admin ARM endpoint
+$TenantID                  = "<your-aad-tenant-id>"      # Azure AD tenant ID for your Azure Stack Hub
+$HubLocation               = "<your-hub-region>"         # Azure Stack Hub region (e.g., "local", "redmond")
+$StorageEndpointDnsSuffix  = "<region>.<fqdn>"           # External domain suffix (e.g., "local.azurestack.external")
+$KeyVaultDnsSuffix         = "vault.$StorageEndpointDnsSuffix"
+
+# Azure Stack Hub credentials (service admin)
+$ServiceAdminUserName      = "<service-admin-upn>"       # e.g., admin@contoso.onmicrosoft.com
+# Prompt for the password interactively (do NOT hard-code passwords)
+$ServiceAdminCredential    = Get-Credential -UserName $ServiceAdminUserName -Message "Enter Azure Stack Hub Service Admin password"
+
+# Azure Stack Hub storage settings
+$HubResourceGroup          = "ws2025-image-rg"           # Resource group on Azure Stack Hub for the storage account
+$HubStorageAccountName     = "ws2025vhds"                # Storage account name on Azure Stack Hub (3-24 lowercase alphanumeric)
+
+#endregion ==========================================================================
+
+# ==================================================================================
+# Step 1: Install required PowerShell modules
+# ==================================================================================
+Write-Host "`n[Step 1] Installing required PowerShell modules..." -ForegroundColor Cyan
+
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+Install-Module PowershellGet -MinimumVersion 2.2.3 -Repository PSGallery -Force -ErrorAction SilentlyContinue
+
+if ($CleanAzModules) {
+    Write-Host "  -CleanAzModules specified: uninstalling existing Az / Azs / Azure modules (this affects ALL PowerShell sessions on this machine)..." -ForegroundColor Yellow
+    Get-Module -Name Azure* -ListAvailable | Uninstall-Module -Force -Verbose -ErrorAction Continue
+    Get-Module -Name Azs.* -ListAvailable | Uninstall-Module -Force -Verbose -ErrorAction Continue
+    Get-Module -Name Az.* -ListAvailable | Uninstall-Module -Force -Verbose -ErrorAction Continue
+} else {
+    Write-Host "  Skipping module cleanup (re-run with -CleanAzModules if you need a clean reinstall)." -ForegroundColor DarkGray
+}
+
+Install-Module -Name Az.BootStrapper -Repository PSGallery -Force
+Install-AzProfile -Profile 2020-09-01-hybrid -Force
+Install-Module -Name AzureStack -RequiredVersion 2.4.0
+
+Get-Module -Name "Az*" -ListAvailable
+Get-Module -Name "Azs*" -ListAvailable
+
+Import-Module -Name Az -Force -DisableNameChecking | Out-Null
+
+# ==================================================================================
+# Step 2: Log into public Azure and find the latest WS2025 Gen1 image
+# ==================================================================================
+Write-Host "`n[Step 2] Logging into public Azure and finding WS2025 image..." -ForegroundColor Cyan
+
+if ($ClearAzCliAccount) {
+    Write-Host "  -ClearAzCliAccount specified: clearing all cached Azure CLI sessions on this machine..." -ForegroundColor Yellow
+    az account clear
+}
+az login --use-device-code
+az account show
+
+# Find all Windows Server 2025 images (Gen1 only, no Upgrade SKUs)
+Write-Host "Querying Azure Marketplace for Windows Server 2025 images (this can take up to a minute)..." -ForegroundColor Yellow
+$images = az vm image list --all `
+        --publisher MicrosoftWindowsServer `
+        --offer WindowsServer `
+        --output json | ConvertFrom-Json
+
+$filteredImages = $images | Where-Object {
+    $_.sku -like "*2025*" -and $_.sku -inotlike "*Upgrade*"
+}
+
+$gen1Images = $filteredImages | Where-Object {
+    $_.sku -notlike "*-g2" -and
+    $_.sku -notlike "*-gen2" -and
+    $_.sku -inotlike "*azure-edition*"   # Azure Edition SKUs are not supported on Azure Stack Hub
+}
+
+# Group by SKU and pick the latest version of each
+$latestBySku = $gen1Images | Group-Object -Property sku | ForEach-Object {
+    $_.Group | Sort-Object version -Descending | Select-Object -First 1
+} | Sort-Object sku
+
+if (-not $latestBySku -or $latestBySku.Count -eq 0) {
+    throw "No Windows Server 2025 Gen1 images found in the Azure Marketplace."
+}
+
+# Display available images and prompt the user to choose
+Write-Host "`nAvailable Windows Server 2025 Gen1 images:" -ForegroundColor Yellow
+Write-Host ("-" * 80) -ForegroundColor DarkGray
+for ($i = 0; $i -lt $latestBySku.Count; $i++) {
+    $img = $latestBySku[$i]
+    Write-Host "  [$($i + 1)]  $($img.sku)  (version $($img.version))" -ForegroundColor White
+}
+Write-Host ("-" * 80) -ForegroundColor DarkGray
+
+do {
+    $choice = Read-Host "`nEnter the number of the image to download (1-$($latestBySku.Count))"
+    $choiceIndex = $choice -as [int]
+} while ($choiceIndex -lt 1 -or $choiceIndex -gt $latestBySku.Count)
+
+$selectedImage = $latestBySku[$choiceIndex - 1]
+Write-Host "`nSelected image: $($selectedImage.urn)" -ForegroundColor Green
+
+# ==================================================================================
+# Step 3: Create a managed disk from the marketplace image and export VHD
+# ==================================================================================
+Write-Host "`n[Step 3] Creating managed disk and exporting VHD..." -ForegroundColor Cyan
+
+az group create -n $AzureResourceGroup -l $AzureLocation --output none 2>$null
+
+az disk create `
+  -g $AzureResourceGroup `
+  -n $AzureDiskName `
+  --image-reference $selectedImage.urn
+
+$diskAccess = az disk grant-access `
+  --duration-in-seconds 3600 `
+  --access-level Read `
+  --name $AzureDiskName `
+  --resource-group $AzureResourceGroup `
+  -o json | ConvertFrom-Json
+
+# Download AzCopy (recommended over Invoke-WebRequest for large files)
+$azcopyFolder = Join-Path $env:TEMP "azcopy"
+if (Test-Path $azcopyFolder) {
+    Remove-Item $azcopyFolder -Recurse -Force
+}
+New-Item -Path $azcopyFolder -ItemType Directory | Out-Null
+$azcopyZipFile = Join-Path $azcopyFolder "AzCopy.zip"
+Invoke-WebRequest -Uri "https://aka.ms/downloadazcopy-v10-windows" -OutFile $azcopyZipFile
+Expand-Archive -Path $azcopyZipFile -DestinationPath $azcopyFolder -Force
+$azCopyExe = (Get-ChildItem -Path $azcopyFolder -Recurse | Where-Object { $_.Name -eq "azcopy.exe" }).FullName
+if (-not $azCopyExe -or -not (Test-Path $azCopyExe)) {
+    throw "Failed to download or locate azcopy executable."
+}
+
+# Ensure the download directory exists
+$vhdDir = Split-Path $VhdDownloadPath -Parent
+if (-not (Test-Path $vhdDir)) { New-Item -Path $vhdDir -ItemType Directory -Force | Out-Null }
+
+Write-Host "Downloading VHD to $VhdDownloadPath (this may take a while)..." -ForegroundColor Yellow
+& $azCopyExe cp $diskAccess.accessSas $VhdDownloadPath
+
+# Revoke disk access and clean up Azure resources
+az disk revoke-access -g $AzureResourceGroup -n $AzureDiskName
+Write-Host "VHD downloaded successfully." -ForegroundColor Green
+
+# Prompt to delete the temporary Azure resources to avoid ongoing costs
+$cleanup = Read-Host "`nDelete the temporary resource group '$AzureResourceGroup' in Azure to avoid costs? (Y/N)"
+if ($cleanup -ieq 'Y') {
+    Write-Host "Deleting resource group '$AzureResourceGroup'..." -ForegroundColor Yellow
+    az group delete -n $AzureResourceGroup --yes --no-wait --output none
+    Write-Host "Resource group deletion initiated (running in background)." -ForegroundColor Green
+} else {
+    Write-Host "Skipped. Remember to delete resource group '$AzureResourceGroup' manually to avoid costs." -ForegroundColor Yellow
+}
+
+# ==================================================================================
+# Step 4: Connect to Azure Stack Hub
+# ==================================================================================
+Write-Host "`n[Step 4] Connecting to Azure Stack Hub..." -ForegroundColor Cyan
+
+$hubEnvironment = Get-AzEnvironment -Name $EnvironmentName
+if ($hubEnvironment) {
+    Remove-AzEnvironment -Name $EnvironmentName
+}
+
+$response = Invoke-RestMethod "${AdminArmEndpoint}/metadata/endpoints?api-version=1.0"
+Write-Host "  ARM endpoint:      $AdminArmEndpoint"
+Write-Host "  Gallery endpoint:  $($response.galleryEndpoint)"
+
+$hubAdminEnvironmentParams = @{
+    Name                                     = $EnvironmentName
+    ActiveDirectoryEndpoint                  = $response.authentication.loginEndpoint.TrimEnd('/') + "/"
+    ActiveDirectoryServiceEndpointResourceId = $response.authentication.audiences[0]
+    ResourceManagerEndpoint                  = $AdminArmEndpoint
+    GalleryEndpoint                          = $response.galleryEndpoint
+    GraphEndpoint                            = $response.graphEndpoint
+    GraphAudience                            = $response.graphEndpoint
+    EnableAdfsAuthentication                 = $response.authentication.loginEndpoint.TrimEnd("/").EndsWith("/adfs", [System.StringComparison]::OrdinalIgnoreCase)
+    StorageEndpoint                          = $StorageEndpointDnsSuffix
+    AzureKeyVaultDnsSuffix                   = $KeyVaultDnsSuffix
+}
+Add-AzEnvironment @hubAdminEnvironmentParams | Out-Null
+$hubEnvironment = Get-AzEnvironment -Name $EnvironmentName
+
+Clear-AzContext -Scope Process -Force -ErrorAction SilentlyContinue | Out-Null
+Connect-AzAccount -Environment $EnvironmentName -Credential $ServiceAdminCredential -Tenant $TenantID
+Write-Host "Connected to Azure Stack Hub." -ForegroundColor Green
+Get-AzSubscription | Format-Table -Property SubscriptionId, Name, TenantId
+
+# ==================================================================================
+# Step 5: Upload VHD to Azure Stack Hub storage account
+# ==================================================================================
+Write-Host "`n[Step 5] Uploading VHD to Azure Stack Hub..." -ForegroundColor Cyan
+
+New-AzResourceGroup -Name $HubResourceGroup -Location $HubLocation -Force | Out-Null
+
+New-AzStorageAccount `
+  -ResourceGroupName $HubResourceGroup `
+  -Name $HubStorageAccountName `
+  -Location $HubLocation `
+  -SkuName Standard_LRS
+
+$storageKeys = Get-AzStorageAccountKey -ResourceGroupName $HubResourceGroup -Name $HubStorageAccountName
+$ctx = New-AzStorageContext -StorageAccountName $HubStorageAccountName -StorageAccountKey $storageKeys[0].Value
+
+$osUri = "https://$HubStorageAccountName.blob.$StorageEndpointDnsSuffix/vhds/WS2025-datacenter.vhd"
+
+Write-Host "Uploading VHD (this may take a while)..." -ForegroundColor Yellow
+Add-AzVhd `
+    -LocalFilePath $VhdDownloadPath `
+    -ResourceGroupName $HubResourceGroup `
+    -Destination $osUri
+
+Write-Host "VHD uploaded successfully." -ForegroundColor Green
+
+# ==================================================================================
+# Step 6: Register as a platform image in Azure Stack Hub marketplace
+# ==================================================================================
+Write-Host "`n[Step 6] Registering platform image in Azure Stack Hub marketplace..." -ForegroundColor Cyan
+
+$storageAccount = Get-AzStorageAccount -ResourceGroupName $HubResourceGroup -Name $HubStorageAccountName
+$ctx = $storageAccount.Context
+$containerName = "vhds"
+$blobName = "WS2025-datacenter.vhd"
+$sasToken = New-AzStorageBlobSASToken `
+    -Container $containerName `
+    -Blob $blobName `
+    -Permission r `
+    -ExpiryTime (Get-Date).AddHours(24) `
+    -Context $ctx
+$osSasUri = "$($ctx.BlobEndPoint)$containerName/$blobName$sasToken"
+
+Add-AzsPlatformImage `
+    -Location $HubLocation `
+    -Publisher "MicrosoftWindowsServer" `
+    -Offer "WindowsServer" `
+    -Sku $selectedImage.sku `
+    -Version $selectedImage.version `
+    -OSType "Windows" `
+    -OSUri $osSasUri
+
+# Verify the image was registered
+$platformImages = Get-AzsPlatformImage
+$ws2025Image = $platformImages | Where-Object {
+    $_.Publisher -eq "MicrosoftWindowsServer" -and
+    $_.Offer -eq "WindowsServer" -and
+    $_.Sku -eq $selectedImage.sku
+}
+
+if ($ws2025Image) {
+    Write-Host "`nWindows Server 2025 ($($selectedImage.sku)) image registered successfully!" -ForegroundColor Green
+    $ws2025Image | Format-List
+} else {
+    Write-Host "`nWarning: Image registration could not be verified." -ForegroundColor Yellow
+}
+
+Write-Host "`nDone." -ForegroundColor Cyan

--- a/Support/create-ws2025-image-from-azure/README.md
+++ b/Support/create-ws2025-image-from-azure/README.md
@@ -1,0 +1,252 @@
+> **Disclaimer:** This is provided as an **example only** and is **not a supported service offering**. It is provided under the [MIT License](https://opensource.org/licenses/MIT) on an **"as-is" basis, without warranty of any kind**, express or implied. Use at your own risk.
+
+# Windows Server 2025 Image for Azure Stack Hub
+
+Scripts to download a **Windows Server 2025 Datacenter** GEN1 VHD from the Azure Marketplace and register it as a platform image in **Azure Stack Hub**.
+
+## Overview
+
+Azure Stack Hub operators who cannot use the built-in Marketplace syndication (e.g., disconnected or partially-connected environments) can use these scripts to manually obtain and import the WS2025 image.
+
+### Workflow
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│  PUBLIC AZURE                                                                   │
+│                                                                                 │
+│  Step 1 ─ Install Az & AzureStack PowerShell modules                            │
+│                                                                                 │
+│  Step 2 ─ Log in via Azure CLI (device-code flow)                               │
+│           Query Marketplace for latest WS2025 Gen1 image URN                    │
+│                                                                                 │
+│  Step 3 ─ Create a temporary managed disk from the Marketplace image            │
+│           Grant read access → generate SAS URL                                  │
+│           Download the VHD to the local machine using AzCopy                    │
+│           Revoke disk access                                                    │
+│                              │                                                  │
+└──────────────────────────────┼──────────────────────────────────────────────────┘
+                               │  Save VHD file on local disk, and transfer
+                               ▼
+┌─────────────────────────────────────────────────────────────────────────────────┐
+│  AZURE STACK HUB (Admin ARM Endpoint)                                           │
+│                                                                                 │
+│  Step 4 ─ Register the Hub environment & connect as Service Admin               │
+│                                                                                 │
+│  Step 5 ─ Create a storage account on the Hub Admin                             │
+│           Upload the VHD with Add-AzVhd                                         │
+│                                                                                 │
+│  Step 6 ─ Register the VHD as a platform image (Add-AzsPlatformImage)           │
+│           Verify the image appears in the Hub Marketplace                       │
+│                                                                                 │
+└─────────────────────────────────────────────────────────────────────────────────┘
+```
+
+| Step | Environment | What happens | Tools used |
+|------|-------------|-------------|------------|
+| **1** | Local machine | Installs the required PowerShell modules (`Az` 2020-09-01-hybrid profile, `AzureStack 2.4.0`). | `Install-Module` |
+| **2** | Public Azure | Logs in via Azure CLI with device-code auth, then queries the Marketplace for the latest **Windows Server 2025 Datacenter Gen1** image URN (excluding Gen2 & Upgrade SKUs). | `az login`, `az vm image list` |
+| **3** | Public Azure → Local | Creates a temporary **managed disk** from the Marketplace image, grants read access to obtain a SAS URL, and downloads the disk as a fixed-size VHD using **AzCopy v10**. Revokes disk access when done. | `az disk create`, `az disk grant-access`, AzCopy |
+| **4** | Azure Stack Hub | Registers the Hub's Admin ARM endpoint as a PowerShell environment and authenticates as the **Service Admin**. | `Add-AzEnvironment`, `Connect-AzAccount` |
+| **5** | Azure Stack Hub | Creates a resource group and storage account on the Hub, then uploads the local VHD using `Add-AzVhd`. | `New-AzStorageAccount`, `Add-AzVhd` |
+| **6** | Azure Stack Hub | Registers the uploaded VHD as a **platform image** (publisher: `MicrosoftWindowsServer`, offer: `WindowsServer`, SKU: `2025-Datacenter`) and verifies it is available in the Hub Marketplace for tenant use. | `Add-AzsPlatformImage`, `Get-AzsPlatformImage` |
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| **OS** | Windows (scripts use PowerShell 5.1+) |
+| **Azure CLI** | Required for marketplace image discovery and disk operations. Install with `_Pre-req_Install_AzCLI.ps1`. |
+| **Azure subscription** | Needed temporarily to create a managed disk from the marketplace image. |
+| **Azure Stack Hub admin access** | Service Admin credentials and the Admin ARM endpoint. |
+| **Disk space** | ~30 GB for the full-disk VHD, ~10 GB for small-disk. |
+| **PowerShell modules** | Installed automatically by the script: `Az` (2020-09-01-hybrid profile), `AzureStack 2.4.0`. |
+
+> [!IMPORTANT]
+> **Service Admin authentication (no MFA).**
+> The script uses `Connect-AzAccount -Credential`, which **does not support MFA or Conditional Access**. Use a Service Admin account that is exempt from MFA, or modify Step 4 to use interactive `Connect-AzAccount -Environment $EnvironmentName -Tenant $TenantID` (drop `-Credential`).
+
+> [!IMPORTANT]
+> **Hub admin endpoint certificate must be trusted.**
+> Step 4 calls `Invoke-RestMethod` against the Hub admin ARM endpoint. If that endpoint uses an internal CA / self-signed certificate that is not trusted on the workstation, the call will fail. Import the Hub's CA certificate into the workstation's Trusted Root store before running the script.
+
+## Scripts
+
+### `_Pre-req_Install_AzCLI.ps1`
+
+Installs Azure CLI on Windows and adds it to the system PATH. Run this first if Azure CLI is not already installed.
+
+```powershell
+# Run as Administrator
+.\_Pre-req_Install_AzCLI.ps1
+```
+
+### `Example_WS2025-create-image-from-Azure.ps1`
+
+Main script that performs the full end-to-end workflow. **Before running**, open the script and update the parameters in the `PARAMETERS` section at the top:
+
+| Parameter | Description | Example |
+|---|---|---|
+| `$AzureResourceGroup` | Temp resource group in Azure for the managed disk | `ws2025-image-rg` |
+| `$VhdDownloadPath` | Local path to save the VHD | `C:\VHDs\WS2025-datacenter.vhd` |
+| `$AdminArmEndpoint` | Azure Stack Hub admin ARM endpoint | `https://adminmanagement.local.azurestack.external` |
+| `$TenantID` | Azure AD tenant ID | `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` |
+| `$HubLocation` | Azure Stack Hub region name | `local` |
+| `$StorageEndpointDnsSuffix` | External domain suffix | `local.azurestack.external` |
+| `$ServiceAdminUserName` | Service admin UPN | `admin@contoso.onmicrosoft.com` |
+| `$HubResourceGroup` | Resource group on the Hub for storage | `ws2025-image-rg` |
+| `$HubStorageAccountName` | Storage account name on the Hub | `ws2025vhds` |
+
+```powershell
+# Run as Administrator
+.\Example_WS2025-create-image-from-Azure.ps1
+```
+
+The script will prompt for the service admin password interactively.
+
+**Optional switches:**
+
+| Switch | Effect |
+|---|---|
+| `-CleanAzModules` | Uninstalls every existing `Az.*` / `Azs.*` / `Azure*` PowerShell module before installing the hybrid profile. **Off by default** because this affects every PowerShell session on the workstation, not just this script. Use only when you need a clean reinstall. |
+| `-ClearAzCliAccount` | Runs `az account clear` before login, removing all cached Azure CLI sessions on the machine. **Off by default.** |
+| `-AzureLocation <region>` | Public-Azure region used to create the temporary managed disk. Defaults to `eastus`. |
+
+## VM Licensing & Billing (ARM `LicenseType`)
+
+This section covers **billing**: how Microsoft meters and charges for the Windows Server VM. It is controlled by the `LicenseType` ARM property on the VM resource, set **per-VM** at deployment time (and changeable later with stop/deallocate + `Update-AzVM`). It is **not** part of the platform image.
+
+> **Note:** Azure Stack Hub is considered **on-premises hardware** for licensing purposes. Azure Hybrid Use Benefit (AHUB) is **not required** to use your own Windows Server licenses on Azure Stack Hub (see the [Azure Stack Hub Licensing Guide](https://go.microsoft.com/fwlink/?LinkId=2273601&clcid=0x409) FAQ).
+
+### Pay-as-you-use billing model
+
+In the pay-as-you-use model, Azure Stack Hub meters each VM and reports usage to Azure Commerce. The `LicenseType` property controls which meter is used:
+
+| `LicenseType` value | Meter used | When to use |
+|---|---|---|
+| *Not set* (default) | **Windows Server VM meter** — Windows license cost is included in the per-vCPU/min rate. | You do not have your own Windows Server licenses. |
+| `"Windows_Server"` | **Base VM meter** only — lower rate, no Windows license cost included. | You are bringing your own on-premises Windows Server licenses covering all physical cores in the Azure Stack Hub region. |
+
+**Default (Windows Server PAYG VM meter):**
+
+```powershell
+# No LicenseType — Windows license included in billing
+New-AzVM -ResourceGroupName "myRG" -Name "myVM" `
+    -Image "MicrosoftWindowsServer:WindowsServer:2025-Datacenter:latest" `
+    -Location "local" `
+    -Credential (Get-Credential)
+```
+
+**Using your own Windows Server license (Base VM meter):**
+
+```powershell
+# LicenseType = "Windows_Server" — bring your own license, billed at Base VM rate
+New-AzVM -ResourceGroupName "myRG" -Name "myVM" `
+    -Image "MicrosoftWindowsServer:WindowsServer:2025-Datacenter:latest" `
+    -LicenseType "Windows_Server" `
+    -Location "local" `
+    -Credential (Get-Credential)
+```
+
+**ARM Template (under `Microsoft.Compute/virtualMachines` properties):**
+
+```json
+{
+  "type": "Microsoft.Compute/virtualMachines",
+  "properties": {
+    "licenseType": "Windows_Server",
+    ...
+  }
+}
+```
+
+**Update an existing VM:**
+
+```powershell
+$vm = Get-AzVM -ResourceGroupName "myRG" -Name "myVM"
+$vm.LicenseType = "Windows_Server"
+Update-AzVM -ResourceGroupName "myRG" -VM $vm
+```
+
+> **Important:** When bringing your own Windows Server licenses, you must have enough Windows Server core licenses to cover **all physical cores** in the Azure Stack Hub region, regardless of how many Windows Server VMs are actually deployed. All cores must be covered with the **same edition** — all Datacenter **or** all Standard — because a VM can be scheduled on any node in the region (Datacenter is recommended for heavily virtualised workloads). Volume Licensing customers must also hold sufficient **Windows Server CALs** for the use case.
+
+### Capacity billing model
+
+In the capacity model, Windows Server guest licenses are **not included** in the annual per-core subscription fee. You must have separate Windows Server Volume Licensing (VL) licenses covering all physical cores in the Azure Stack Hub region. The `LicenseType` property has no billing effect in this model since usage is not reported to Azure Commerce.
+
+For official information, refer to the [Azure Stack Hub Licensing, Packaging & Pricing Guide](https://go.microsoft.com/fwlink/?LinkId=2273601&clcid=0x409).
+
+> [!IMPORTANT]
+> **`LicenseType` (billing) and KMS (activation) are two separate, independent concerns.**
+>
+> - `LicenseType` controls **billing** — which meter Azure Commerce uses for the VM.
+> - **KMS** controls **activation** — how the guest OS proves it is genuine.
+>
+> A VM can be PAYG-billed and KMS-activated, **or** BYOL-billed and KMS-activated. The activation method does not change the meter, and the meter does not change activation. They never need to "match".
+
+## Guest OS Activation (KMS)
+
+This section covers **guest OS activation**: how the Windows Server 2025 guest OS proves it is genuine. Activation lives **inside the guest OS**, completely outside ARM. It has **no** effect on billing, does not talk to ARM, and does not read `LicenseType`.
+
+**KMS activation is required** for Windows Server 2025 guest VMs on Azure Stack Hub:
+
+- **AVMA** (Automatic Virtual Machine Activation) is **not supported** for Windows Server 2025 guests on Azure Stack Hub.
+- The **Azure-hosted KMS endpoints** used by public Azure marketplace images are not reachable/applicable on Hub.
+- **MAK** keys can be used but are typically reserved for one-off / disconnected scenarios.
+
+Ensure your environment has access to a reachable **KMS host** (e.g., an on-premises KMS server) so that WS2025 VMs can activate after deployment.
+
+### Billing and activation are independent — supported combinations
+
+Any supported activation method works with **either** billing model. The activation host (KMS / MAK) does not query ARM and has no knowledge of `LicenseType`; the Azure Commerce meter has no knowledge of how the OS activated. Pick the billing model and activation method **independently**, based on what you have available:
+
+| `LicenseType` (billing) | Activation method | Supported on Hub? | Typical use |
+|---|---|---|---|
+| *unset* — **PAYG** (Windows Server VM meter) | **On-prem KMS** | ✅ Yes | **Most common** — Windows licence is in the meter; on-prem KMS handles the activation handshake. No region-wide licensing obligation. |
+| *unset* — **PAYG** | **MAK** | ✅ Yes | Works, but uses up a MAK activation count for no commercial benefit; rarely the right choice. |
+| *unset* — **PAYG** | **AVMA** | ❌ No | AVMA is not supported for WS2025 guests on Hub. |
+| *unset* — **PAYG** | **Azure-hosted KMS** | ❌ No | Public-Azure KMS endpoints are not reachable from Hub. |
+| `Windows_Server` — **BYOL** (Base VM meter) | **On-prem KMS** | ✅ Yes | Standard BYOL pattern; requires region-wide WS Datacenter/Standard licensing (all physical cores, same edition). |
+| `Windows_Server` — **BYOL** | **MAK** | ✅ Yes | Useful for disconnected or one-off scenarios. |
+| `Windows_Server` — **BYOL** | **AVMA** | ❌ No | AVMA is not supported for WS2025 guests on Hub. |
+
+> **Key point:** "PAYG with on-prem KMS" is a **fully supported, normal configuration** — and it is the right default for tenants who do not want to commit to BYOL's all-physical-cores licensing obligation. Activating via KMS does **not** make the VM "BYOL", and it does **not** mean you are double-paying. Under PAYG, the Windows Server licence entitlement is provided by the meter you are paying; KMS is only the technical handshake that confirms the OS is genuine.
+
+> **Important — KMS is activation, not licensing:** Using KMS to activate Windows Server 2025 VMs does **not** remove or bypass any licensing obligation you have for Windows Server. KMS is only an **activation mechanism** — it confirms the OS is genuine and enables full functionality, but it does not grant a licence entitlement. The licensing obligation depends on your billing model:
+>
+> - **PAYG** (`LicenseType` unset, Windows Server VM meter) — the Windows Server licence is included in the per-vCPU meter; no separate Windows Server licences are required.
+> - **BYOL** (`LicenseType="Windows_Server"`, Base VM meter) — you must hold valid Windows Server licences (e.g., Datacenter or Standard) covering **every physical core** in the Azure Stack Hub region, per the [Hub Licensing Guide](https://go.microsoft.com/fwlink/?LinkId=2273601&clcid=0x409).
+> - **Capacity model** — Windows Server guest licences are **not** included in the capacity fee; separate Volume Licensing covering every physical core is required.
+>
+> KMS activation succeeding does not, on its own, prove you are correctly licensed under any of these models.
+
+### Common conflations between billing and activation
+
+These two axes are frequently mixed up. The table below maps the symptom to the actual cause and the (incorrect) conclusion that often follows:
+
+| Symptom | Real cause | Category | Wrong conclusion |
+|---|---|---|---|
+| WS2025 VM won't activate after deploy | No KMS host reachable | Activation | "BYOL is broken on Hub" |
+| Bill shows full Windows VM rate despite owning licences | Forgot `LicenseType=Windows_Server` | Billing | "PAYG and BYOL can't mix" |
+| Marketplace image deployed on Hub doesn't auto-activate | Azure KMS endpoint not present on Hub | Activation | "The PAYG image is incompatible with BYOL" |
+| `LicenseType` flipped but bill unchanged for a day | Usage meters batch / VM still running old state | Billing | "Mixing modes confuses the meter" |
+
+None of these are "PAYG vs BYOL can't coexist" — they are either an **activation** problem or a **`LicenseType` configuration** problem.
+
+## Notes
+
+- The script downloads **AzCopy v10** automatically — no manual installation needed.
+- Only **Gen1** (non-Gen2) images are selected, as Azure Stack Hub requires Gen1 VHDs.
+- After the image is registered, it appears in the Azure Stack Hub Marketplace and can be used by tenant subscriptions to create VMs.
+- To clean up the temporary Azure resources after the VHD is downloaded, delete the resource group specified in `$AzureResourceGroup`.
+
+## License
+
+MIT License
+
+Copyright (c) 2025-2026
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+**THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**

--- a/Support/create-ws2025-image-from-azure/_Pre-req_Install_AzCLI.ps1
+++ b/Support/create-ws2025-image-from-azure/_Pre-req_Install_AzCLI.ps1
@@ -1,0 +1,108 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Installs Azure CLI on Windows and adds it to the system PATH.
+
+.DESCRIPTION
+    DISCLAIMER: This script is provided as an EXAMPLE ONLY and is NOT a supported service
+    offering. It is provided under the MIT License on an "AS-IS" basis, without warranty
+    of any kind, express or implied. Use at your own risk.
+
+    Downloads and installs the latest Azure CLI MSI for Windows x64,
+    adds it to the system and session PATH, and verifies the installation.
+
+.NOTES
+    Must be run as Administrator (for MSI install and system PATH modification).
+#>
+
+# Ensure TLS 1.2 for downloads from aka.ms / Microsoft endpoints
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# Set variables
+$downloadUrl = "https://aka.ms/installazurecliwindowsx64"
+$installerPath = "$env:TEMP\AzureCLI.msi"
+$azureCliPath = "${env:ProgramFiles}\Microsoft SDKs\Azure\CLI2\wbin"
+
+Write-Host "Azure CLI Installation Script" -ForegroundColor Cyan
+Write-Host "==============================" -ForegroundColor Cyan
+
+# Download Azure CLI installer
+Write-Host "`nDownloading Azure CLI installer..." -ForegroundColor Yellow
+try {
+    Invoke-WebRequest -Uri $downloadUrl -OutFile $installerPath -UseBasicParsing
+    Write-Host "Download completed successfully." -ForegroundColor Green
+} catch {
+    Write-Host "Error downloading installer: $_" -ForegroundColor Red
+    exit 1
+}
+
+# Install Azure CLI
+Write-Host "`nInstalling Azure CLI..." -ForegroundColor Yellow
+try {
+    Start-Process msiexec.exe -Wait -ArgumentList "/I $installerPath /quiet" -NoNewWindow
+    Write-Host "Installation completed successfully." -ForegroundColor Green
+} catch {
+    Write-Host "Error during installation: $_" -ForegroundColor Red
+    exit 1
+}
+
+# Add to PATH if not already present
+Write-Host "`nChecking PATH environment variable..." -ForegroundColor Yellow
+$machinePath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine)
+$currentSessionPath = $env:Path
+
+# Add to system PATH
+if ($machinePath -notlike "*$azureCliPath*") {
+    Write-Host "Adding Azure CLI to system PATH..." -ForegroundColor Yellow
+    try {
+        [Environment]::SetEnvironmentVariable(
+            "Path",
+            "$machinePath;$azureCliPath",
+            [EnvironmentVariableTarget]::Machine
+        )
+        Write-Host "Azure CLI added to system PATH successfully." -ForegroundColor Green
+    } catch {
+        Write-Host "Error adding to system PATH: $_" -ForegroundColor Red
+        Write-Host "You may need to run this script as Administrator." -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "Azure CLI is already in system PATH." -ForegroundColor Green
+}
+
+# Add to current session PATH
+if ($currentSessionPath -notlike "*$azureCliPath*") {
+    Write-Host "Adding Azure CLI to current session PATH..." -ForegroundColor Yellow
+    $env:Path += ";${env:ProgramFiles}\Microsoft SDKs\Azure\CLI2\wbin"; 
+    Set-Alias az "${env:ProgramFiles}\Microsoft SDKs\Azure\CLI2\wbin\az.cmd" -Scope Global
+    Write-Host "Azure CLI added to current session successfully." -ForegroundColor Green
+    Write-Host "You can now use 'az' commands in this session!" -ForegroundColor Cyan
+} else {
+    Write-Host "Azure CLI is already in current session PATH." -ForegroundColor Green
+}
+
+# Clean up installer
+Write-Host "`nCleaning up..." -ForegroundColor Yellow
+Remove-Item $installerPath -Force -ErrorAction SilentlyContinue
+
+# Verify installation
+Write-Host "`nVerifying installation..." -ForegroundColor Yellow
+try {
+    # Update PATH for current session to ensure az is available
+    $env:Path = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine)
+    
+    $azVersion = az --version 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "`nAzure CLI installed successfully!" -ForegroundColor Green
+        Write-Host "Version information:" -ForegroundColor Cyan
+        Write-Host $azVersion
+    } else {
+        Write-Host "Installation completed but verification failed." -ForegroundColor Yellow
+        Write-Host "Try running 'az --version' manually." -ForegroundColor Yellow
+    }
+} catch {
+    Write-Host "Could not verify installation immediately." -ForegroundColor Yellow
+    Write-Host "Try running 'az --version' manually." -ForegroundColor Yellow
+}
+
+Write-Host "`nInstallation process completed!" -ForegroundColor Green
+Write-Host "You can now use 'az' commands in this terminal session!" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

Adds a new **example** under `Support/create-ws2025-image-from-azure/` that walks Hub operators through downloading a Windows Server 2025 Datacenter GEN1 VHD from the Azure Marketplace and registering it as a platform image on Azure Stack Hub. This can be useful, as there is no Windows Server 2025 Marketplace image available for syndication from Azure marketplace for Azure Stack Hub.

> Provided as an **example only** — not a supported service offering. MIT-licensed, AS-IS.

## What's included

- **`Example_WS2025-create-image-from-Azure.ps1`** — end-to-end script:
  1. Installs the required Az / AzureStack hybrid modules.
  2. Logs into public Azure via the Azure CLI and lists WS2025 GEN1 SKUs (excluding `-gen2`, `-upgrade`, and `azure-edition`).
  3. Creates a temp managed disk from the chosen marketplace image and downloads the VHD via AzCopy v10.
  4. Connects to the Hub admin ARM endpoint as Service Admin.
  5. Uploads the VHD to a Hub storage account.
  6. Registers it as a platform image (`Add-AzsPlatformImage`) and verifies.

  Supports `-CleanAzModules`, `-ClearAzCliAccount`, and `-AzureLocation` switches; destructive cleanup is **off by default**.

- **`_Pre-req_Install_AzCLI.ps1`** — installs Azure CLI on Windows and adds it to PATH. Enforces `#Requires -RunAsAdministrator` and TLS 1.2.

- **`README.md`** — workflow diagram, prerequisites, parameter reference, optional-switch reference, and a detailed write-up of **VM Licensing & Billing (`LicenseType`)** vs **Guest OS Activation (KMS)** for WS2025 on Hub, including the supported `LicenseType` × activation-method matrix and common conflations.

## Notes for reviewers

- Only GEN1 SKUs are surfaced (Hub doesn't support GEN2 platform images).
- README calls out two important prerequisites: the Service Admin account must be MFA-exempt (uses `Connect-AzAccount -Credential`), and the Hub admin endpoint certificate must be trusted on the workstation.
- No existing files are modified; this is purely additive under `Support/`.