### PR TITLE
WS2025 example GEN1 image creation

### DIFF
--- a/Support/create-ws2025-image-from-azure/README.md
+++ b/Support/create-ws2025-image-from-azure/README.md
@@ -6,7 +6,7 @@ Scripts to download a **Windows Server 2025 Datacenter** GEN1 VHD from the Azure
 
 ## Overview
 
-Azure Stack Hub operators who cannot use the built-in Marketplace syndication (e.g., disconnected or partially-connected environments) can use these scripts to manually obtain and import the WS2025 image.
+Azure Stack Hub operators can use these scripts to manually obtain and import a Windows Server 2025 VM image.
 
 ### Workflow
 


### PR DESCRIPTION
Minor wording update to `Support/create-ws2025-image-from-azure/README.md` overview.

Generalizes the audience description for the WS2025 GEN1 image creation example so it isn't limited to disconnected/partially-connected scenarios — any Azure Stack Hub operator can use these scripts to manually obtain and import a Windows Server 2025 VM image.

## Change

```diff
-Azure Stack Hub operators who cannot use the built-in Marketplace syndication (e.g., disconnected or partially-connected environments) can use these scripts to manually obtain and import the WS2025 image.
+Azure Stack Hub operators can use these scripts to manually obtain and import a Windows Server 2025 VM image.
```
